### PR TITLE
fix: error instead of panicking on higher migration level

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -99,6 +99,8 @@ pub enum MigrationDefinitionError {
     },
     /// Attempt to migrate when no migrations are defined
     NoMigrationsDefined,
+    /// Attempt to migrate when the database is currently at a higher migration level (see https://github.com/cljoly/rusqlite_migration/issues/17)
+    DatabaseTooFarAhead,
 }
 
 impl fmt::Display for MigrationDefinitionError {
@@ -115,6 +117,12 @@ impl fmt::Display for MigrationDefinitionError {
             }
             MigrationDefinitionError::NoMigrationsDefined => {
                 write!(f, "Attempt to migrate with no migrations defined")
+            }
+            MigrationDefinitionError::DatabaseTooFarAhead => {
+                write!(
+                    f,
+                    "Attempt to migrate a database with a migration number that is too high"
+                )
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,11 @@ impl<'m> Migrations<'m> {
 
         let res = match target_db_version.cmp(&current_version) {
             Ordering::Less => {
+                if current_version > self.ms.len() {
+                    return Err(Error::MigrationDefinition(
+                        MigrationDefinitionError::DatabaseTooFarAhead,
+                    ));
+                }
                 debug!(
                     "rollback to older version requested, target_db_version: {}, current_version: {}",
                     target_db_version, current_version


### PR DESCRIPTION
When we encounter a database whose migration number is higher than the
highest migration, we currently panic. With this change, we just return
an error.

Fixes #17
