### PR TITLE
Add foreign_key_check method to migrations

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,8 @@ pub enum Error {
     SpecifiedSchemaVersion(SchemaVersionError),
     /// Something wrong with migration definitions
     MigrationDefinition(MigrationDefinitionError),
+    /// The foreign key check failed
+    ForeignKeyCheck(ForeignKeyCheckError),
 }
 
 impl Error {
@@ -48,6 +50,7 @@ impl std::error::Error for Error {
             Error::RusqliteError { query: _, err } => Some(err),
             Error::SpecifiedSchemaVersion(e) => Some(e),
             Error::MigrationDefinition(e) => Some(e),
+            Error::ForeignKeyCheck(e) => Some(e),
         }
     }
 }
@@ -129,3 +132,24 @@ impl fmt::Display for MigrationDefinitionError {
 }
 
 impl std::error::Error for MigrationDefinitionError {}
+
+/// Error caused by a foreign key check
+#[derive(Debug, PartialEq, Clone)]
+pub struct ForeignKeyCheckError {
+    pub(super) table: String,
+    pub(super) rowid: i64,
+    pub(super) parent: String,
+    pub(super) fkid: i64,
+}
+
+impl fmt::Display for ForeignKeyCheckError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Foreign key check found a row {} on table {} missing from {} but required by {}",
+            self.rowid, self.table, self.parent, self.fkid
+        )
+    }
+}
+
+impl std::error::Error for ForeignKeyCheckError {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -146,7 +146,7 @@ impl fmt::Display for ForeignKeyCheckError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Foreign key check found a row {} in table {} missing from {} \
+            "Foreign key check found a row {} in table '{}' missing from table '{}' \
             but required by foreign key with id {}",
             self.rowid, self.table, self.parent, self.fkid
         )

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -146,7 +146,8 @@ impl fmt::Display for ForeignKeyCheckError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Foreign key check found a row {} on table {} missing from {} but required by {}",
+            "Foreign key check found a row {} in table {} missing from {} \
+            but required by foreign key with id {}",
             self.rowid, self.table, self.parent, self.fkid
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ limitations under the License.
 //!
 
 use log::{debug, info, trace, warn};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
 use rusqlite::NO_PARAMS;
 
@@ -95,7 +95,7 @@ mod errors;
 
 #[cfg(test)]
 mod tests;
-pub use errors::{Error, MigrationDefinitionError, Result, SchemaVersionError};
+pub use errors::{Error, MigrationDefinitionError, Result, SchemaVersionError, ForeignKeyCheckError};
 use std::{
     cmp::{self, Ordering},
     fmt,
@@ -107,6 +107,7 @@ use std::{
 pub struct M<'u> {
     up: &'u str,
     down: Option<&'u str>,
+    foreign_key_check: bool,
 }
 
 impl<'u> M<'u> {
@@ -138,6 +139,7 @@ impl<'u> M<'u> {
         Self {
             up: sql,
             down: None,
+            foreign_key_check: false,
         }
     }
 
@@ -156,6 +158,22 @@ impl<'u> M<'u> {
     /// ```
     pub const fn down(mut self, sql: &'u str) -> Self {
         self.down = Some(sql);
+        self
+    }
+
+    /// Enable an automatic validation of foreign keys before the migration transaction is closed.
+    /// This will cause the migration to fail if `PRAGMA foreign_key_check` returns any rows.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rusqlite_migration::M;
+    ///
+    /// M::up("CREATE TABLE animals (name TEXT);")
+    ///     .foreign_key_check();
+    /// ```
+    pub const fn foreign_key_check(mut self) -> Self {
+        self.foreign_key_check = true;
         self
     }
 }
@@ -296,6 +314,10 @@ impl<'m> Migrations<'m> {
 
             tx.execute_batch(m.up)
                 .map_err(|e| Error::with_sql(e, m.up))?;
+
+            if m.foreign_key_check {
+                validate_foreign_keys(&tx)?;
+            }
         }
         set_user_version(&tx, target_version)?;
         tx.commit()?;
@@ -538,4 +560,26 @@ fn set_user_version(conn: &Connection, v: usize) -> Result<()> {
             query: format!("PRAGMA user_version = {}; -- Approximate query", v),
             err: e,
         })
+}
+
+// Validate that no foreign keys are violated
+fn validate_foreign_keys(conn: &Connection) -> Result<()> {
+    #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
+    conn.query_row("PRAGMA foreign_key_check", NO_PARAMS, |row| {
+        Ok(ForeignKeyCheckError {
+            table: row.get(0)?,
+            rowid: row.get(1)?,
+            parent: row.get(2)?,
+            fkid: row.get(3)?,
+        })
+    })
+    .optional()
+    .map_err(|e| Error::RusqliteError {
+        query: String::from("PRAGMA foreign_key_check"),
+        err: e,
+    })
+    .and_then(|o| match o {
+        Some(e) => Err(Error::ForeignKeyCheck(e)),
+        None => Ok(()),
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,15 +87,17 @@ limitations under the License.
 //!
 
 use log::{debug, info, trace, warn};
-use rusqlite::{Connection, OptionalExtension};
 #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
 use rusqlite::NO_PARAMS;
+use rusqlite::{Connection, OptionalExtension};
 
 mod errors;
 
 #[cfg(test)]
 mod tests;
-pub use errors::{Error, MigrationDefinitionError, Result, SchemaVersionError, ForeignKeyCheckError};
+pub use errors::{
+    Error, ForeignKeyCheckError, MigrationDefinitionError, Result, SchemaVersionError,
+};
 use std::{
     cmp::{self, Ordering},
     fmt,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,14 +17,17 @@ fn m_valid21() -> M<'static> {
 }
 
 fn m_valid_fk() -> M<'static> {
-    M::up("CREATE TABLE fk1(a PRIMARY KEY); \
+    M::up(
+        "CREATE TABLE fk1(a PRIMARY KEY); \
         CREATE TABLE fk2( \
             a, \
             FOREIGN KEY(a) REFERENCES fk1(a) \
         ); \
         INSERT INTO fk1 (a) VALUES ('foo'); \
         INSERT INTO fk2 (a) VALUES ('foo'); \
-    ").foreign_key_check()
+    ",
+    )
+    .foreign_key_check()
 }
 
 // All valid Ms in the right order
@@ -47,13 +50,16 @@ fn m_invalid1() -> M<'static> {
 }
 
 fn m_invalid_fk() -> M<'static> {
-    M::up("CREATE TABLE fk1(a PRIMARY KEY); \
+    M::up(
+        "CREATE TABLE fk1(a PRIMARY KEY); \
         CREATE TABLE fk2( \
             a, \
             FOREIGN KEY(a) REFERENCES fk1(a) \
         ); \
         INSERT INTO fk2 (a) VALUES ('foo'); \
-    ").foreign_key_check()
+    ",
+    )
+    .foreign_key_check()
 }
 
 #[test]


### PR DESCRIPTION
This implements a method to validate that all foreign keys are still valid after a migration as discussed in #4.
~This still lacks tests, feel free to comment on anything else.~