### PR TITLE
Update repository metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
 categories = ["database"]
 readme = "README.md"
 homepage = "https://cj.rs/rusqlite_migration"
+repository = "https://github.com/cljoly/rusqlite_migration"
 rust-version = "1.61"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Add the missing `repository` metadata. This makes browsing between `crates.io`, `docs.rs` and this repo easier.