### PR TITLE
test: ensure the library builds against old rusqlite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,21 @@ jobs:
         with:
           command: test
 
+  min_dependencies_version:
+    name: Check with minimal versions of each dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -Z minimal-versions
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to be as flexible as possible in the rusqlite versions we
accept, even if we can’t run all the tests against older versions.

Fixes #33
