### PR TITLE
Fix pedantic warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Rusqlite Migration is a simple and performant schema migration library for [rusq
 
 ## Example
 
-Here, we define SQL statements to run with [Migrations::new](crate::Migrations::new) and run these (if necessary) with [.to_latest()](crate::Migrations::to_latest).
+Here, we define SQL statements to run with [`Migrations::new()`] and run these (if necessary) with [`Migrations::to_latest()`].
 
 ``` rust
 use rusqlite::{params, Connection};

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["SQLite", "rusqlite_migration", "serde_rusqlite", "lazy_static", ".."]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,6 +31,7 @@ pub enum Error {
 
 impl Error {
     /// Associtate the SQL request that caused the error
+    #[must_use]
     pub fn with_sql(e: rusqlite::Error, sql: &str) -> Error {
         Error::RusqliteError {
             query: String::from(sql),


### PR DESCRIPTION
This PR fixes all warnings with `-W clippy::pedantic` except for the potential truncation/sign loss problems.