### PR TITLE
Follow-up on clippy pedantic warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Rusqlite Migration is a simple and performant schema migration library for [rusq
 
 ## Example
 
-Here, we define SQL statements to run with [`Migrations::new()`] and run these (if necessary) with [`Migrations::to_latest()`].
+Here, we define SQL statements to run with [`Migrations::new()`][migrations_new] and run these (if necessary) with [`Migrations::to_latest()`][migrations_to_latest].
+
+[migrations_new]: https://docs.rs/rusqlite_migration/latest/rusqlite_migration/struct.Migrations.html#method.new
+[migrations_to_latest]: https://docs.rs/rusqlite_migration/latest/rusqlite_migration/struct.Migrations.html#method.to_latest
 
 ``` rust
 use rusqlite::{params, Connection};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@ limitations under the License.
 //!
 //! ## Example
 //!
-//! Here, we define SQL statements to run with [`Migrations::new()`] and run these (if necessary) with [`Migrations::to_latest()`].
+//! Here, we define SQL statements to run with [`Migrations::new()`][migrations_new] and run these (if necessary) with [`Migrations::to_latest()`][migrations_to_latest].
+//!
+//! [migrations_new]: https://docs.rs/rusqlite_migration/latest/rusqlite_migration/struct.Migrations.html#method.new
+//! [migrations_to_latest]: https://docs.rs/rusqlite_migration/latest/rusqlite_migration/struct.Migrations.html#method.to_latest
 //!
 //! ``` rust
 //! use rusqlite::{params, Connection};
@@ -713,4 +716,3 @@ fn validate_foreign_keys(conn: &Connection) -> Result<()> {
         None => Ok(()),
     })
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,7 +669,10 @@ impl<'m> Migrations<'m> {
 
 // Read user version field from the SQLite db
 fn user_version(conn: &Connection) -> Result<usize, rusqlite::Error> {
-    #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
+    // To keep compatibility with lower rusqlite versions
+    #[allow(deprecated)]
+    // We can’t fix this without breaking API compatibility
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     conn.query_row("PRAGMA user_version", NO_PARAMS, |row| row.get(0))
         .map(|v: i64| v as usize)
 }
@@ -677,6 +680,8 @@ fn user_version(conn: &Connection) -> Result<usize, rusqlite::Error> {
 // Set user version field from the SQLite db
 fn set_user_version(conn: &Connection, v: usize) -> Result<()> {
     trace!("set user version to: {}", v);
+    // We can’t fix this without breaking API compatibility
+    #[allow(clippy::cast_possible_truncation)]
     let v = v as u32;
     // To keep compatibility with lower rusqlite versions, allow the needless `&v` borrow
     #[allow(clippy::needless_borrow)]
@@ -708,3 +713,4 @@ fn validate_foreign_keys(conn: &Connection) -> Result<()> {
         None => Ok(()),
     })
 }
+


### PR DESCRIPTION
- style: silence some clippy pedantic warnings
- docs: fix links in the example

cc @matze this builds on #38
