### PR TITLE
Fix example test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,23 @@ jobs:
           command: test
           args: --features async-tokio-rusqlite
 
+  test_examples:
+    name: Test examples
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./examples
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
   min_rust_version:
     name: Check with minimal Rust version
     runs-on: ubuntu-latest

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -9,9 +9,9 @@ use tokio_rusqlite::Connection;
 mod tests {
     use super::*;
 
-    #[test]
-    fn migrations_test() {
-        assert!(MIGRATIONS.validate().is_ok());
+    #[tokio::test]
+    async fn migrations_test() {
+        assert!(MIGRATIONS.validate().await.is_ok());
     }
 }
 


### PR DESCRIPTION
The `async` example had an incorrect test. Fixed it and also added an new CI pipeline to verify the examples so it cannot happen in the future.