### PR TITLE
Fix `AsyncMigrations::new` documentation

### DIFF
--- a/rusqlite_migration/src/asynch.rs
+++ b/rusqlite_migration/src/asynch.rs
@@ -10,7 +10,7 @@ pub struct AsyncMigrations {
 }
 
 impl AsyncMigrations {
-    /// Adapt a [Migrations](crate::Migrations) instance for use in an asynchronous context.
+    /// Create a proxy struct to a [Migrations](crate::Migrations) instance for use in an asynchronous context.
     ///
     /// # Example
     ///


### PR DESCRIPTION
The documentation was incorrectly stating that this method "adapts" something, when it creates a proxy.