### PR TITLE
refactor: misc. style and robustness improvements

### DIFF
--- a/rusqlite_migration/src/errors.rs
+++ b/rusqlite_migration/src/errors.rs
@@ -30,7 +30,7 @@ pub enum Error {
 }
 
 impl Error {
-    /// Associtate the SQL request that caused the error
+    /// Associate the SQL request that caused the error
     #[must_use]
     pub fn with_sql(e: rusqlite::Error, sql: &str) -> Error {
         Error::RusqliteError {
@@ -179,10 +179,7 @@ impl From<rusqlite::Error> for HookError {
 impl From<HookError> for Error {
     fn from(e: HookError) -> Error {
         match e {
-            HookError::RusqliteError(err) => Error::RusqliteError {
-                query: String::new(),
-                err,
-            },
+            HookError::RusqliteError(err) => Error::with_sql(err, ""),
             HookError::Hook(s) => Error::Hook(s),
         }
     }

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -388,7 +388,7 @@ fn invalid_fk_check_test() {
 
 #[test]
 fn all_valid_test() {
-    assert_eq!(Ok(()), Migrations::new(all_valid()).validate())
+    assert_eq!(Ok(()), Migrations::new(all_valid()).validate());
 }
 
 // If we encounter a database with a migration number higher than the number of defined migration,

--- a/rusqlite_migration_tests/tests/up_and_down.rs
+++ b/rusqlite_migration_tests/tests/up_and_down.rs
@@ -139,6 +139,9 @@ fn test_errors() {
         let migrations = Migrations::new(ms.clone());
 
         migrations.to_latest(&mut conn).unwrap();
+        // Successful even on the second run (the most common case once migrations have been
+        // applied)
+        migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(
             Ok(SchemaVersion::Inside(NonZeroUsize::new(3).unwrap())),


### PR DESCRIPTION
* A string was manually copied to create an error, so the error could
  become inaccurate as the string may become out of date.
* Use `with_sql` method when possible without incurring extra allocation
* Fix typo in documentation
* Improve some logging directive (in particular, inlining the variables)
