### PR TITLE
fix: adapt to rusqlite 0.29 and tighten the requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.0.2
+
+### Bug fix
+
+* fix: adapt to rusqlite 0.29 and tighten dependency requirements for rusqlite (see [this discussion](https://github.com/cljoly/rusqlite_migration/issues/68#issuecomment-1485795284))
+
 ## Version 1.0.1
 
 ### Bug Fix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite_migration"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Clément Joly <l@131719.xyz>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ homepage = "https://cj.rs/rusqlite_migration"
 log = "0.4"
 
 [dependencies.rusqlite]
-version = ">=0.23.0"
+version = ">=0.23.0,<=0.29.0"
 default-features = false
 features = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,7 @@ limitations under the License.
 //!
 
 use log::{debug, info, trace, warn};
-use rusqlite::Connection;
-#[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-use rusqlite::NO_PARAMS;
+use rusqlite::{Connection, ToSql};
 
 mod errors;
 
@@ -525,7 +523,7 @@ impl<'m> Migrations<'m> {
 // Read user version field from the SQLite db
 fn user_version(conn: &Connection) -> Result<usize, rusqlite::Error> {
     #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-    conn.query_row("PRAGMA user_version", NO_PARAMS, |row| row.get(0))
+    conn.query_row::<_, &[&dyn ToSql], _>("PRAGMA user_version", &[], |row| row.get(0))
         .map(|v: i64| v as usize)
 }
 

--- a/tests/multiline_test.rs
+++ b/tests/multiline_test.rs
@@ -3,6 +3,8 @@ use std::num::NonZeroUsize;
 use rusqlite::{params, Connection};
 use rusqlite_migration::{Migrations, SchemaVersion, M};
 
+const NO_PARAMS: &[&dyn rusqlite::ToSql] = &[];
+
 #[test]
 fn main_test() {
     simple_logging::log_to_stderr(log::LevelFilter::Trace);
@@ -41,7 +43,7 @@ fn main_test() {
         conn.query_row(
             "SELECT * FROM pragma_journal_mode",
             #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-            rusqlite::NO_PARAMS,
+            NO_PARAMS,
             |row| {
                 assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
                 Ok(())
@@ -52,7 +54,7 @@ fn main_test() {
         conn.query_row(
             "SELECT * FROM pragma_foreign_keys",
             #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-            rusqlite::NO_PARAMS,
+            NO_PARAMS,
             |row| {
                 assert_eq!(row.get::<_, bool>(0), Ok(true));
                 Ok(())
@@ -68,7 +70,7 @@ fn main_test() {
         conn.query_row(
             "SELECT * FROM pragma_journal_mode",
             #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-            rusqlite::NO_PARAMS,
+            NO_PARAMS,
             |row| {
                 assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
                 Ok(())


### PR DESCRIPTION
As discussed in #69, currently, version 1.0.1 of `rusqlite_migration` is incompatible with rusqlite version 0.29. The problem is that the Cargo.toml states the contrary, when it says:

```toml
[dependencies.rusqlite]
version = ">=0.23.0"
default-features = false
features = []
```

I think we should treat this as a bug and issue a patch release with a fix.

This commit makes the code compatible with version 0.29. We are lucky that such a code exists and is not too complicated.

As a result, and to fix the second related issue of insufficiently tight version requirements on `rusqlite`, the range is not open-ended anymore and we now constrain the upper bound as well. This means that we won’t have to worry about breaking changes that `rusqlite` version 0.30 may introduce.

I’ve tested this change with all the non-yanked versions of rusqlite and it did `cargo build && cargo test tests::` without issues. The `cargo test tests::` is to exclude documentation test as I don’t want to make these weird due to the workaround for old `rusqlite` versions. I’ve also run the full `cargo test` with `rusqlite` version 0.29 and 0.28, because the documentation examples should be correct for those.

Fixes #68

- [x] Still need to update the Changelog.

**Note: I do not intend to merge this PR, I’ll just tag the last commit and publish a release wih Cargo. But it’s convenient to have a PR to gather feedback**