### PR TITLE
Consider changes to the edit API

### DIFF
--- a/rusqlite_migration/src/builder.rs
+++ b/rusqlite_migration/src/builder.rs
@@ -41,7 +41,7 @@ impl<'u> MigrationsBuilder<'u> {
     /// Errors:
     ///
     /// Panics in case a migration with a given `id` does not exist.
-    pub fn edit(mut self, id: usize, f: impl Fn(&mut M)) -> Self {
+    pub fn edit(mut self, id: usize, f: impl Fn(M) -> M) -> Self {
         if id < 1 {
             panic!("id cannot be equal to 0");
         }


### PR DESCRIPTION
Maybe we can keep more flexibility for the future by passing a owned `M` in edit.

Depends on #77
