### PR TITLE
refactor!: deprecate `Migrations::from_iter`

### DIFF
--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -459,7 +459,10 @@ impl<'m> Migrations<'m> {
         })
     }
 
+    /// **Deprecated**: [`Migrations`] now implements [`FromIterator`], so use [`Migrations::from_iter`] instead.
+    ///
     /// Performs allocations transparently.
+    #[deprecated = "Use the `FromIterator` trait implementation instead. For instance, you can call Migrations::from_iter."]
     pub fn new_iter<I: IntoIterator<Item = M<'m>>>(ms: I) -> Self {
         Self::new(Vec::from_iter(ms))
     }


### PR DESCRIPTION
We are now implementing the standard `FromIterator` trait.
