### PR TITLE
Migrate to the newest tokio-rusqlite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 name: Continuous integration
 
 env:
-  MSRV: 1.61.0
+  MSRV: 1.64.0
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### Minimum Rust Version
 
+Rust 1.64
+
+## Version 1.1.0 Alpha 1
+
+**⚠️ The APIs exposed in this version may be unstable.**
+
+### Minimum Rust Version
+
 Rust 1.61
 
 ### New Features

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.10"
 anyhow = "1"
 lazy_static = "1.4.0"
 mktemp = "0.5"
-tokio-rusqlite = "0.3.0"
+tokio-rusqlite = "0.4.0"
 tokio = { version = "1.25.0", features = ["full"] }
 
 [dependencies.rusqlite_migration]
@@ -19,6 +19,6 @@ path = "../../rusqlite_migration"
 features = ["async-tokio-rusqlite"]
 
 [dependencies.rusqlite]
-version = ">=0.23.0"
+version = ">=0.29.0"
 default-features = false
 features = []

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -17,6 +17,6 @@ mktemp = "0.5"
 include_dir = "0.7.3"
 
 [dependencies.rusqlite]
-version = ">=0.23.0"
+version = ">=0.29.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -14,6 +14,6 @@ lazy_static = "1.4.0"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = ">=0.23.0"
+version = ">=0.29.0"
 default-features = false
 features = []

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 readme = "README.md"
 homepage = "https://cj.rs/rusqlite_migration"
 repository = "https://github.com/cljoly/rusqlite_migration"
-rust-version = "1.61"
+rust-version = "1.64"
 
 [features]
 default = []

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -23,11 +23,11 @@ from-directory = ["dep:include_dir"]
 [dependencies]
 include_dir = { version = "0.7.3", optional = true }
 tokio = { version = "1.25", features = ["macros"], optional = true }
-tokio-rusqlite = { version = "0.3.0", optional = true }
+tokio-rusqlite = { version = "0.4.0", optional = true }
 log = "0.4"
 
 [dependencies.rusqlite]
-version = ">=0.23.0"
+version = ">=0.29.0"
 default-features = false
 features = []
 
@@ -39,7 +39,10 @@ env_logger = "0.10"
 anyhow = "1"
 lazy_static = "1.4.0"
 mktemp = "0.5"
-criterion = { version = "0.4", features = ["html_reports", "cargo_bench_support"] }
+criterion = { version = "0.4", features = [
+    "html_reports",
+    "cargo_bench_support",
+] }
 iai = "0.1"
 
 [[bench]]

--- a/rusqlite_migration/benches/from_directory.rs
+++ b/rusqlite_migration/benches/from_directory.rs
@@ -23,17 +23,18 @@ static MIGRATIONS_DIR_10: Dir = include_dir!("$CARGO_MANIFEST_DIR/benches/10_mig
 static MIGRATIONS_DIR_100: Dir = include_dir!("$CARGO_MANIFEST_DIR/benches/100_migrations");
 
 // Iai
-
+#[allow(dead_code)]
 pub fn small() {
     Migrations::from_directory(&MIGRATIONS_DIR_10).unwrap();
 }
 
+#[allow(dead_code)]
 pub fn big() {
     Migrations::from_directory(&MIGRATIONS_DIR_100).unwrap();
 }
 
 // Criterion
-
+#[allow(dead_code)]
 pub fn create_bench(c: &mut Criterion) {
     c.bench_function("from_directory_small", |b| {
         b.iter_with_large_drop(|| Migrations::from_directory(&MIGRATIONS_DIR_10).unwrap())

--- a/rusqlite_migration/benches/iai.rs
+++ b/rusqlite_migration/benches/iai.rs
@@ -14,6 +14,8 @@ limitations under the License.
 
 */
 
+use std::iter::FromIterator;
+
 use iai::black_box;
 use rusqlite::Connection;
 use rusqlite_migration::{Migrations, M};
@@ -31,7 +33,7 @@ fn upward(i: u64) {
         })
         .collect::<Vec<_>>();
     let migrations =
-        Migrations::new_iter(sql_migrations.iter().enumerate().map(|(i, (up, down))| {
+        Migrations::from_iter(sql_migrations.iter().enumerate().map(|(i, (up, down))| {
             let m = M::up(up).down(down);
             if i % 500 == 0 {
                 m.foreign_key_check()

--- a/rusqlite_migration/src/asynch.rs
+++ b/rusqlite_migration/src/asynch.rs
@@ -80,7 +80,9 @@ impl AsyncMigrations {
     #[allow(clippy::missing_errors_doc)]
     pub async fn current_version(&self, async_conn: &AsyncConnection) -> Result<SchemaVersion> {
         let m = self.migrations.clone();
-        async_conn.call(move |conn| m.current_version(conn)).await
+        async_conn
+            .call(move |conn| Ok(m.current_version(conn)))
+            .await?
     }
 
     /// Asynchronous version of the same method in the [Migrations](super::Migrations::to_latest) struct.
@@ -108,7 +110,7 @@ impl AsyncMigrations {
     #[allow(clippy::missing_errors_doc)]
     pub async fn to_latest(&self, async_conn: &mut AsyncConnection) -> Result<()> {
         let m = self.migrations.clone();
-        async_conn.call(move |conn| m.to_latest(conn)).await
+        async_conn.call(move |conn| Ok(m.to_latest(conn))).await?
     }
 
     /// Asynchronous version of the same method in the [Migrations](crate::Migrations::to_version) struct.
@@ -131,21 +133,21 @@ impl AsyncMigrations {
     ///
     /// // Go back to version 1, i.e. after running the first migration
     /// migrations.to_version(&mut conn, 1).await;
-    /// conn.call(|conn| conn.execute("INSERT INTO animals (name) VALUES (?)", ["dog"])).await.unwrap();
-    /// conn.call(|conn| conn.execute("INSERT INTO food (name) VALUES (?)", ["carrot"]).unwrap_err()).await;
+    /// conn.call(|conn| Ok(conn.execute("INSERT INTO animals (name) VALUES (?)", ["dog"]))).await.unwrap();
+    /// conn.call(|conn| Ok(conn.execute("INSERT INTO food (name) VALUES (?)", ["carrot"]).unwrap_err())).await;
     ///
     /// // Go back to an empty database
     /// migrations.to_version(&mut conn, 0).await;
-    /// conn.call(|conn| conn.execute("INSERT INTO animals (name) VALUES (?)", ["cat"]).unwrap_err()).await;
-    /// conn.call(|conn| conn.execute("INSERT INTO food (name) VALUES (?)", ["milk"]).unwrap_err()).await;
+    /// conn.call(|conn| Ok(conn.execute("INSERT INTO animals (name) VALUES (?)", ["cat"]).unwrap_err())).await;
+    /// conn.call(|conn| Ok(conn.execute("INSERT INTO food (name) VALUES (?)", ["milk"]).unwrap_err())).await;
     /// # })
     /// ```
     #[allow(clippy::missing_errors_doc)]
     pub async fn to_version(&self, async_conn: &mut AsyncConnection, version: usize) -> Result<()> {
         let m = self.migrations.clone();
         async_conn
-            .call(move |conn| m.to_version(conn, version))
-            .await
+            .call(move |conn| Ok(m.to_version(conn, version)))
+            .await?
     }
 
     /// Asynchronous version of the same method in the [Migrations](crate::Migrations::validate) struct.

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -103,8 +103,6 @@ limitations under the License.
 //!
 
 use log::{debug, info, trace, warn};
-#[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-use rusqlite::NO_PARAMS;
 use rusqlite::{Connection, OptionalExtension, Transaction};
 
 #[cfg(feature = "from-directory")]
@@ -784,7 +782,7 @@ fn user_version(conn: &Connection) -> Result<usize, rusqlite::Error> {
     #[allow(deprecated)]
     // We can’t fix this without breaking API compatibility
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    conn.query_row("PRAGMA user_version", NO_PARAMS, |row| row.get(0))
+    conn.query_row("PRAGMA user_version", [], |row| row.get(0))
         .map(|v: i64| v as usize)
 }
 
@@ -807,7 +805,7 @@ fn set_user_version(conn: &Connection, v: usize) -> Result<()> {
 fn validate_foreign_keys(conn: &Connection) -> Result<()> {
     let pragma_fk_check = "PRAGMA foreign_key_check";
     #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-    conn.query_row(pragma_fk_check, NO_PARAMS, |row| {
+    conn.query_row(pragma_fk_check, [], |row| {
         Ok(ForeignKeyCheckError {
             table: row.get(0)?,
             rowid: row.get(1)?,

--- a/rusqlite_migration/src/tests/builder.rs
+++ b/rusqlite_migration/src/tests/builder.rs
@@ -7,7 +7,7 @@ use crate::{MigrationsBuilder, M};
 fn test_non_existing_index() {
     let ms = vec![M::up("CREATE TABLE t(a);")];
 
-    MigrationsBuilder::from_iter(ms.clone()).edit(100, move |_t| {});
+    let _ = MigrationsBuilder::from_iter(ms.clone()).edit(100, move |_t| {});
 }
 
 #[test]
@@ -15,5 +15,5 @@ fn test_non_existing_index() {
 fn test_0_index() {
     let ms = vec![M::up("CREATE TABLE t(a);")];
 
-    MigrationsBuilder::from_iter(ms).edit(0, move |_t| {});
+    let _ = MigrationsBuilder::from_iter(ms).edit(0, move |_t| {});
 }

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -525,7 +525,7 @@ fn eq_hook_test() {
     ];
     // When there are no hooks, migrations can be cloned and still be equal
     {
-        let migrations = Migrations::new_iter(vec_migrations.clone().into_iter().take(2));
+        let migrations = Migrations::from_iter(vec_migrations.clone().into_iter().take(2));
 
         assert_eq!(migrations, migrations.clone());
     }

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["database"]
 readme = "README.md"
 homepage = "https://cj.rs/rusqlite_migration"
 repository = "https://github.com/cljoly/rusqlite_migration"
-rust-version = "1.61"
+rust-version = "1.64"
 publish = false
 
 [dependencies]

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 
 [dependencies]
 tokio = { version = "1.25", features = ["macros"] }
-tokio-rusqlite = { version = "0.3.0" }
+tokio-rusqlite = { version = "0.4.0" }
 log = "0.4"
 
 [dependencies.rusqlite_migration]
@@ -23,7 +23,7 @@ path = "../rusqlite_migration"
 features = ["async-tokio-rusqlite", "from-directory"]
 
 [dependencies.rusqlite]
-version = ">=0.23.0"
+version = ">=0.29.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/tests/async_from_directory_test.rs
+++ b/rusqlite_migration_tests/tests/async_from_directory_test.rs
@@ -28,7 +28,9 @@ async fn main_test() {
                 params!["John", "1970-01-01"],
             )
             .unwrap();
+            Ok(())
         })
-        .await;
+        .await
+        .unwrap();
     }
 }

--- a/rusqlite_migration_tests/tests/async_up_and_down.rs
+++ b/rusqlite_migration_tests/tests/async_up_and_down.rs
@@ -36,10 +36,12 @@ async fn main_test() {
         migrations.to_version(&mut conn, 1).await.unwrap();
 
         conn.call(|conn| {
-            conn.execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
-                .unwrap();
+            Ok(conn
+                .execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
+                .unwrap())
         })
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(
             Ok(SchemaVersion::Inside(NonZeroUsize::new(1).unwrap())),
@@ -51,10 +53,12 @@ async fn main_test() {
 
         // the table is gone now
         conn.call(|conn| {
-            conn.execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
-                .unwrap_err();
+            Ok(conn
+                .execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
+                .unwrap_err())
         })
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(
             Ok(SchemaVersion::NoneSet),
@@ -104,8 +108,11 @@ async fn main_test() {
                 params![15, 0],
             )
             .unwrap();
+
+            Ok(())
         })
-        .await;
+        .await
+        .unwrap();
 
         // go back
         migrations.to_version(&mut conn, 3).await.unwrap();
@@ -130,8 +137,11 @@ async fn main_test() {
                 params![1, 0],
             )
             .unwrap();
+
+            Ok(())
         })
-        .await;
+        .await
+        .unwrap();
     }
 }
 
@@ -162,8 +172,10 @@ async fn test_errors() {
         conn.call(|conn| {
             conn.execute("INSERT INTO animals (name) VALUES (?1)", params!["Dog"])
                 .unwrap();
+            Ok(())
         })
-        .await;
+        .await
+        .unwrap();
 
         // go back
         assert!(migrations.to_version(&mut conn, 0).await.is_err()); // oops

--- a/rusqlite_migration_tests/tests/multiline_test.rs
+++ b/rusqlite_migration_tests/tests/multiline_test.rs
@@ -36,26 +36,16 @@ fn main_test() {
         )
         .unwrap();
 
-        conn.query_row(
-            "SELECT * FROM pragma_journal_mode",
-            #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-            rusqlite::NO_PARAMS,
-            |row| {
-                assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
-                Ok(())
-            },
-        )
+        conn.query_row("SELECT * FROM pragma_journal_mode", [], |row| {
+            assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
+            Ok(())
+        })
         .unwrap();
 
-        conn.query_row(
-            "SELECT * FROM pragma_foreign_keys",
-            #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-            rusqlite::NO_PARAMS,
-            |row| {
-                assert_eq!(row.get::<_, bool>(0), Ok(true));
-                Ok(())
-            },
-        )
+        conn.query_row("SELECT * FROM pragma_foreign_keys", [], |row| {
+            assert_eq!(row.get::<_, bool>(0), Ok(true));
+            Ok(())
+        })
         .unwrap();
     }
 
@@ -63,15 +53,10 @@ fn main_test() {
     {
         let conn = Connection::open(&db_file).unwrap();
 
-        conn.query_row(
-            "SELECT * FROM pragma_journal_mode",
-            #[allow(deprecated)] // To keep compatibility with lower rusqlite versions
-            rusqlite::NO_PARAMS,
-            |row| {
-                assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
-                Ok(())
-            },
-        )
+        conn.query_row("SELECT * FROM pragma_journal_mode", [], |row| {
+            assert_eq!(row.get::<_, String>(0), Ok(String::from("wal")));
+            Ok(())
+        })
         .unwrap();
 
         conn.execute(


### PR DESCRIPTION
Migrate `tokio-rusqlite` to the newest version handling the new `ConnectionClosed` error condition.