### PR TITLE
doc: make the deps badge more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ end_insert -->
 {{< /rawhtml >}}
 end_insert -->
 
-[![docs.rs](https://img.shields.io/docsrs/rusqlite_migration)](https://docs.rs/rusqlite_migration) [![Crates.io](https://img.shields.io/crates/v/rusqlite_migration)](https://crates.io/crates/rusqlite_migration) [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/) [![dependency status](https://deps.rs/repo/github/cljoly/rusqlite_migration/status.svg)](https://deps.rs/repo/github/cljoly/rusqlite_migration) [![Coveralls](https://img.shields.io/coverallsCoverage/github/cljoly/rusqlite_migration)](https://coveralls.io/github/cljoly/rusqlite_migration)
+[![docs.rs](https://img.shields.io/docsrs/rusqlite_migration)](https://docs.rs/rusqlite_migration) [![Crates.io](https://img.shields.io/crates/v/rusqlite_migration)](https://crates.io/crates/rusqlite_migration) [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/) [![dependency status](https://deps.rs/crate/rusqlite_migration/1.0.2/status.svg)](https://deps.rs/crate/rusqlite_migration) [![Coveralls](https://img.shields.io/coverallsCoverage/github/cljoly/rusqlite_migration)](https://coveralls.io/github/cljoly/rusqlite_migration)
 
 <!-- insert
 {{< rawhtml >}}


### PR DESCRIPTION
Currently, we report on the status of the dependencies in the dev
version (i.e. the lastest master commit of the GitHub repository). This
a bit misleading, because users of the library usually pull the latest
stable and use it. Whether dependencies are up to date for the latest
stable is quite different from the dev version.

This updated URL reports on the latest version. The drawback is that one
has to manually update the path when a new stable version is released.
