### PR TITLE
Fix ConnectionClosed mapping

### DIFF
--- a/rusqlite_migration/src/errors.rs
+++ b/rusqlite_migration/src/errors.rs
@@ -78,7 +78,9 @@ impl std::error::Error for Error {
             Error::SpecifiedSchemaVersion(e) => Some(e),
             Error::MigrationDefinition(e) => Some(e),
             Error::ForeignKeyCheck(e) => Some(e),
-            Error::Hook(_) | Error::FileLoad(_) | Error::ConnectionClosed => None,
+            Error::Hook(_) | Error::FileLoad(_) => None,
+            #[cfg(feature = "async-tokio-rusqlite")]
+            Error::ConnectionClosed => None,
             Error::Unrecognized(ref e) => Some(&**e),
         }
     }


### PR DESCRIPTION
Fix ConnectionClosed mapping when `async-tokio-rusqlite` is disabled.