### PR TITLE
Improve edit api

### DIFF
--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -452,9 +452,12 @@ impl<'m> Migrations<'m> {
     /// or don't contain at least a valid `up.sql` file.
     #[cfg(feature = "from-directory")]
     pub fn from_directory(dir: &'static Dir<'static>) -> Result<Self> {
-        Ok(Self {
-            ms: from_directory(dir)?,
-        })
+        let migrations = from_directory(dir)?
+            .into_iter()
+            .collect::<Option<Vec<_>>>()
+            .ok_or(Error::FileLoad("Could not load migrations".to_string()))?;
+
+        Ok(Self { ms: migrations })
     }
 
     /// **Deprecated**: [`Migrations`] now implements [`FromIterator`], so use [`Migrations::from_iter`] instead.

--- a/rusqlite_migration/src/loader.rs
+++ b/rusqlite_migration/src/loader.rs
@@ -90,7 +90,7 @@ impl<'u> From<&MigrationFile> for M<'u> {
     }
 }
 
-pub(crate) fn from_directory(dir: &'static Dir<'static>) -> Result<Vec<M<'static>>> {
+pub(crate) fn from_directory(dir: &'static Dir<'static>) -> Result<Vec<Option<M<'static>>>> {
     let mut migrations: Vec<Option<M>> = vec![None; dir.dirs().count()];
 
     for dir in dir.dirs() {
@@ -127,8 +127,5 @@ pub(crate) fn from_directory(dir: &'static Dir<'static>) -> Result<Vec<M<'static
     }
 
     // The values are returned in the order of the keys, i.e. of IDs
-    migrations
-        .into_iter()
-        .collect::<Option<Vec<_>>>()
-        .ok_or(Error::FileLoad("Could not load migrations".to_string()))
+    Ok(migrations)
 }

--- a/rusqlite_migration/src/tests/builder.rs
+++ b/rusqlite_migration/src/tests/builder.rs
@@ -7,7 +7,7 @@ use crate::{MigrationsBuilder, M};
 fn test_non_existing_index() {
     let ms = vec![M::up("CREATE TABLE t(a);")];
 
-    let _ = MigrationsBuilder::from_iter(ms.clone()).edit(100, move |_t| {});
+    let _ = MigrationsBuilder::from_iter(ms.clone()).edit(100, move |t| t);
 }
 
 #[test]
@@ -15,5 +15,5 @@ fn test_non_existing_index() {
 fn test_0_index() {
     let ms = vec![M::up("CREATE TABLE t(a);")];
 
-    let _ = MigrationsBuilder::from_iter(ms).edit(0, move |_t| {});
+    let _ = MigrationsBuilder::from_iter(ms).edit(0, move |t| t);
 }


### PR DESCRIPTION
This PR implements my take on #86. The edit api now takes ownership of the migration it edits.


Closes #86