### PR TITLE
Require new version of rusqlite

### DIFF
--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -19,6 +19,6 @@ path = "../../rusqlite_migration"
 features = ["async-tokio-rusqlite"]
 
 [dependencies.rusqlite]
-version = ">=0.29.0"
+version = "=0.29.0"
 default-features = false
 features = []

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -17,6 +17,6 @@ mktemp = "0.5"
 include_dir = "0.7.3"
 
 [dependencies.rusqlite]
-version = ">=0.29.0"
+version = "=0.29.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -14,6 +14,6 @@ lazy_static = "1.4.0"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = ">=0.29.0"
+version = "=0.29.0"
 default-features = false
 features = []

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -27,7 +27,7 @@ tokio-rusqlite = { version = "0.4.0", optional = true }
 log = "0.4"
 
 [dependencies.rusqlite]
-version = ">=0.29.0"
+version = "=0.29.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -23,7 +23,7 @@ path = "../rusqlite_migration"
 features = ["async-tokio-rusqlite", "from-directory"]
 
 [dependencies.rusqlite]
-version = ">=0.29.0"
+version = "=0.29.0"
 default-features = false
 features = []
 


### PR DESCRIPTION
Changes the minimal supported `rusqlite` version to `0.29.0`. 

Closes #69 