### PR TITLE
Remove unnecessary dead_code markers

### DIFF
--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -179,7 +179,6 @@ pub struct M<'u> {
     down: Option<&'u str>,
     down_hook: Option<Box<dyn MigrationHook>>,
     foreign_key_check: bool,
-    #[allow(dead_code)]
     comment: Option<&'u str>,
 }
 


### PR DESCRIPTION
This is not `dead_code` any more, since this field is used.

Closes #75 