### PR TITLE
Make down migrations respect the `foreign_key_check` setting

### DIFF
--- a/rusqlite_migration/benches/iai.rs
+++ b/rusqlite_migration/benches/iai.rs
@@ -27,8 +27,8 @@ fn upward(i: u64) {
     let sql_migrations = (0..=i)
         .map(|i| {
             (
-                format!("CREATE TABLE t{}(a, b, c);", i),
-                format!("DROP TABLE t{};", i),
+                format!("CREATE TABLE t{i}(a, b, c);"),
+                format!("DROP TABLE t{i};"),
             )
         })
         .collect::<Vec<_>>();

--- a/rusqlite_migration/src/tests/helpers.rs
+++ b/rusqlite_migration/src/tests/helpers.rs
@@ -30,6 +30,21 @@ pub fn m_valid_fk() -> M<'static> {
     .foreign_key_check()
 }
 
+pub fn m_invalid_down_fk() -> M<'static> {
+    M::up(
+        "CREATE TABLE fk1(a PRIMARY KEY); \
+        CREATE TABLE fk2( \
+            a, \
+            FOREIGN KEY(a) REFERENCES fk1(a) \
+        ); \
+        INSERT INTO fk1 (a) VALUES ('foo'); \
+        INSERT INTO fk2 (a) VALUES ('foo'); \
+    ",
+    )
+    .foreign_key_check()
+    .down("DROP TABLE fk1;")
+}
+
 // All valid Ms in the right order
 pub fn all_valid() -> Vec<M<'static>> {
     vec![

--- a/rusqlite_migration_tests/tests/async_up_and_down.rs
+++ b/rusqlite_migration_tests/tests/async_up_and_down.rs
@@ -154,7 +154,8 @@ async fn test_errors() {
         M::up("CREATE TABLE food (id INTEGER, name TEXT);"), // no down!!!
         // 2
         M::up("CREATE TABLE animal_food (animal_id INTEGER, food_id INTEGER);")
-            .down("DROP TABLE animal_food;"),
+            .down("DROP TABLE animal_food;")
+            .foreign_key_check(),
     ];
 
     {


### PR DESCRIPTION
This change enables `foreign_key_check` for downward migrations.

TODO:
- [x] Sum up the discussions from #4. @cljoly I'm not sure what is important to sum up and where to place it :D.

Closes #4.