### PR TITLE
Extract test helper methods

### DIFF
--- a/rusqlite_migration/src/tests/asynch.rs
+++ b/rusqlite_migration/src/tests/asynch.rs
@@ -1,69 +1,13 @@
 use std::iter::FromIterator;
 
-use crate::{AsyncMigrations, Error, MigrationDefinitionError, M};
+use crate::{
+    tests::helpers::{
+        all_valid, m_invalid0, m_invalid1, m_invalid_fk, m_valid0, m_valid10, m_valid11, m_valid20,
+        m_valid21, m_valid_fk,
+    },
+    AsyncMigrations, Error, MigrationDefinitionError,
+};
 use tokio_rusqlite::Connection as AsyncConnection;
-
-fn m_valid0() -> M<'static> {
-    M::up("CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);")
-}
-fn m_valid10() -> M<'static> {
-    M::up("CREATE TABLE t1(a, b);")
-}
-fn m_valid11() -> M<'static> {
-    M::up("ALTER TABLE t1 RENAME COLUMN b TO c;")
-}
-fn m_valid20() -> M<'static> {
-    M::up("CREATE TABLE t2(b);")
-}
-fn m_valid21() -> M<'static> {
-    M::up("ALTER TABLE t2 ADD COLUMN a;")
-}
-
-fn m_valid_fk() -> M<'static> {
-    M::up(
-        "CREATE TABLE fk1(a PRIMARY KEY); \
-        CREATE TABLE fk2( \
-            a, \
-            FOREIGN KEY(a) REFERENCES fk1(a) \
-        ); \
-        INSERT INTO fk1 (a) VALUES ('foo'); \
-        INSERT INTO fk2 (a) VALUES ('foo'); \
-    ",
-    )
-    .foreign_key_check()
-}
-
-// All valid Ms in the right order
-fn all_valid() -> Vec<M<'static>> {
-    vec![
-        m_valid0(),
-        m_valid10(),
-        m_valid11(),
-        m_valid20(),
-        m_valid21(),
-        m_valid_fk(),
-    ]
-}
-
-fn m_invalid0() -> M<'static> {
-    M::up("CREATE TABLE table3()")
-}
-fn m_invalid1() -> M<'static> {
-    M::up("something invalid")
-}
-
-fn m_invalid_fk() -> M<'static> {
-    M::up(
-        "CREATE TABLE fk1(a PRIMARY KEY); \
-        CREATE TABLE fk2( \
-            a, \
-            FOREIGN KEY(a) REFERENCES fk1(a) \
-        ); \
-        INSERT INTO fk2 (a) VALUES ('foo'); \
-    ",
-    )
-    .foreign_key_check()
-}
 
 #[tokio::test]
 async fn invalid_migration_statement_test() {

--- a/rusqlite_migration/src/tests/helpers.rs
+++ b/rusqlite_migration/src/tests/helpers.rs
@@ -1,0 +1,63 @@
+use crate::M;
+
+pub fn m_valid0() -> M<'static> {
+    M::up("CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);")
+}
+pub fn m_valid10() -> M<'static> {
+    M::up("CREATE TABLE t1(a, b);")
+}
+pub fn m_valid11() -> M<'static> {
+    M::up("ALTER TABLE t1 RENAME COLUMN b TO c;")
+}
+pub fn m_valid20() -> M<'static> {
+    M::up("CREATE TABLE t2(b);")
+}
+pub fn m_valid21() -> M<'static> {
+    M::up("ALTER TABLE t2 ADD COLUMN a;")
+}
+
+pub fn m_valid_fk() -> M<'static> {
+    M::up(
+        "CREATE TABLE fk1(a PRIMARY KEY); \
+        CREATE TABLE fk2( \
+            a, \
+            FOREIGN KEY(a) REFERENCES fk1(a) \
+        ); \
+        INSERT INTO fk1 (a) VALUES ('foo'); \
+        INSERT INTO fk2 (a) VALUES ('foo'); \
+    ",
+    )
+    .foreign_key_check()
+}
+
+// All valid Ms in the right order
+pub fn all_valid() -> Vec<M<'static>> {
+    vec![
+        m_valid0(),
+        m_valid10(),
+        m_valid11(),
+        m_valid20(),
+        m_valid21(),
+        m_valid_fk(),
+    ]
+}
+
+pub fn m_invalid0() -> M<'static> {
+    M::up("CREATE TABLE table3()")
+}
+pub fn m_invalid1() -> M<'static> {
+    M::up("something invalid")
+}
+
+pub fn m_invalid_fk() -> M<'static> {
+    M::up(
+        "CREATE TABLE fk1(a PRIMARY KEY); \
+        CREATE TABLE fk2( \
+            a, \
+            FOREIGN KEY(a) REFERENCES fk1(a) \
+        ); \
+        INSERT INTO fk2 (a) VALUES ('foo'); \
+    ",
+    )
+    .foreign_key_check()
+}

--- a/rusqlite_migration/src/tests/mod.rs
+++ b/rusqlite_migration/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod asynch;
 mod builder;
+mod helpers;
 mod synch;

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -3,71 +3,12 @@ use std::{iter::FromIterator, num::NonZeroUsize};
 use rusqlite::{Connection, Transaction};
 
 use crate::{
+    tests::helpers::{all_valid, m_invalid_fk, m_valid0, m_valid10, m_valid11, m_valid_fk},
     user_version, Error, ForeignKeyCheckError, MigrationDefinitionError, Migrations, SchemaVersion,
     SchemaVersionError, M,
 };
 
-fn m_valid0() -> M<'static> {
-    M::up("CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);")
-}
-fn m_valid10() -> M<'static> {
-    M::up("CREATE TABLE t1(a, b);")
-}
-fn m_valid11() -> M<'static> {
-    M::up("ALTER TABLE t1 RENAME COLUMN b TO c;")
-}
-fn m_valid20() -> M<'static> {
-    M::up("CREATE TABLE t2(b);")
-}
-fn m_valid21() -> M<'static> {
-    M::up("ALTER TABLE t2 ADD COLUMN a;")
-}
-
-fn m_valid_fk() -> M<'static> {
-    M::up(
-        "CREATE TABLE fk1(a PRIMARY KEY); \
-        CREATE TABLE fk2( \
-            a, \
-            FOREIGN KEY(a) REFERENCES fk1(a) \
-        ); \
-        INSERT INTO fk1 (a) VALUES ('foo'); \
-        INSERT INTO fk2 (a) VALUES ('foo'); \
-    ",
-    )
-    .foreign_key_check()
-}
-
-// All valid Ms in the right order
-fn all_valid() -> Vec<M<'static>> {
-    vec![
-        m_valid0(),
-        m_valid10(),
-        m_valid11(),
-        m_valid20(),
-        m_valid21(),
-        m_valid_fk(),
-    ]
-}
-
-fn m_invalid0() -> M<'static> {
-    M::up("CREATE TABLE table3()")
-}
-fn m_invalid1() -> M<'static> {
-    M::up("something invalid")
-}
-
-fn m_invalid_fk() -> M<'static> {
-    M::up(
-        "CREATE TABLE fk1(a PRIMARY KEY); \
-        CREATE TABLE fk2( \
-            a, \
-            FOREIGN KEY(a) REFERENCES fk1(a) \
-        ); \
-        INSERT INTO fk2 (a) VALUES ('foo'); \
-    ",
-    )
-    .foreign_key_check()
-}
+use super::helpers::{m_invalid0, m_invalid1, m_valid20, m_valid21};
 
 #[test]
 fn empty_migrations_test() {


### PR DESCRIPTION
Extract helper methods to their own module shared between `synch` and `asynch` tests.

Closes #98 