### PR TITLE
Fix cargo-mutants in CI

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,1 +1,1 @@
-additional_cargo_args = ["--all-features"]
+additional_cargo_args = ["--no-default-features"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install cargo-mutants
+      - run: cargo install --version 23.9.1 cargo-mutants
       - uses: actions-rs/cargo@v1
         with:
           command: mutants

--- a/rusqlite_migration/src/errors.rs
+++ b/rusqlite_migration/src/errors.rs
@@ -251,6 +251,21 @@ mod tests {
         ));
     }
 
+    // Two errors with different queries should be considered different
+    #[test]
+    fn test_rusqlite_error_query() {
+        assert_ne!(
+            Error::RusqliteError {
+                query: "SELECTTT".to_owned(),
+                err: rusqlite::Error::InvalidQuery
+            },
+            Error::RusqliteError {
+                query: "SSSELECT".to_owned(),
+                err: rusqlite::Error::InvalidQuery
+            }
+        )
+    }
+
     // Hook error conversion preserves the message
     #[test]
     fn test_hook_conversion_msg() {

--- a/rusqlite_migration/src/tests/mod.rs
+++ b/rusqlite_migration/src/tests/mod.rs
@@ -1,4 +1,8 @@
+// For feature "async-tokio-rusqlite"
 mod asynch;
+
+// For feature "from-directory"
 mod builder;
+
 mod helpers;
 mod synch;


### PR DESCRIPTION
This is done by a mix of improved tests and pinning of cargo mutants so that it plays nicely with the features of the crate.
