### PR TITLE
chore: refactor cargo manifests and add pkg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,9 @@
 [workspace]
-members = ["rusqlite_migration", "rusqlite_migration_tests"]
+members = [
+  "rusqlite_migration",
+  "rusqlite_migration_tokio_async",
+  "rusqlite_migration_tests",
+]
+
+# https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
+resolver = "2"

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusqlite_migration"
 version = "1.1.0-alpha.3"
-authors = ["Clément Joly <l@131719.xyz>"]
+authors = ["Clément Joly <foss@131719.xyz>"]
 edition = "2018"
 license = "Apache-2.0"
 description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rusqlite_migration_tests"
 version = "1.1.0"
-authors = ["Clément Joly <l@131719.xyz>"]
+authors = ["Clément Joly <foss@131719.xyz>"]
 edition = "2018"
 license = "Apache-2.0"
 description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."

--- a/rusqlite_migration_tokio_async/Cargo.toml
+++ b/rusqlite_migration_tokio_async/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rusqlite_migration_tokio_async"
+version = "0.0.1-alpha1"
+authors = ["Clément Joly <foss@131719.xyz>"]
+edition = "2018"
+license = "Apache-2.0"
+description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."
+keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
+categories = ["database"]
+readme = "README.md"
+homepage = "https://cj.rs/rusqlite_migration"
+repository = "https://github.com/cljoly/rusqlite_migration/tree/master/rusqlite_migration_tokio_async"

--- a/rusqlite_migration_tokio_async/README.md
+++ b/rusqlite_migration_tokio_async/README.md
@@ -1,0 +1,1 @@
+Placeholder until we release the async features of rusqlite_migration as a separate package.

--- a/rusqlite_migration_tokio_async/src/lib.rs
+++ b/rusqlite_migration_tokio_async/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
This is a first step towards #110, as it allows to reserve the package name on crates.io