### PR TITLE
Stop installing an old cargo mutants in CI

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,1 +1,1 @@
-additional_cargo_args = ["--no-default-features"]
+additional_cargo_args = ["--all-features"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,16 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install --version 23.9.1 cargo-mutants
+      - run: cargo install --version 23.12.0 cargo-mutants
       - uses: actions-rs/cargo@v1
         with:
           command: mutants
+      - name: Archive results
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: mutation-report
+          path: mutants.out
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ name: Continuous integration
 env:
   MSRV: 1.70.0
   CARGO_TERM_COLOR: always
+  # Useful for cargo insta
+  CI: true
 
 jobs:
   check:

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -45,6 +45,7 @@ criterion = { version = "0.5", features = [
 ] }
 iai = "0.1"
 insta = "1.34.0"
+mutants = "0.0.3"
 
 [[bench]]
 name = "criterion"

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -44,6 +44,7 @@ criterion = { version = "0.5", features = [
     "cargo_bench_support",
 ] }
 iai = "0.1"
+insta = "1.34.0"
 
 [[bench]]
 name = "criterion"

--- a/rusqlite_migration/src/builder.rs
+++ b/rusqlite_migration/src/builder.rs
@@ -30,6 +30,7 @@ impl<'u> MigrationsBuilder<'u> {
     ///
     /// Returns [`crate::Error::FileLoad`] in case the subdirectory names are incorrect,
     /// or don't contain at least a valid `up.sql` file.
+    #[cfg_attr(test, mutants::skip)] // Tested at a high level
     pub fn from_directory(dir: &'static Dir<'static>) -> Result<Self> {
         Ok(Self {
             migrations: from_directory(dir)?,

--- a/rusqlite_migration/src/errors.rs
+++ b/rusqlite_migration/src/errors.rs
@@ -266,6 +266,34 @@ mod tests {
         )
     }
 
+    // Two errors with different file load errors should be considered different
+    #[test]
+    fn test_rusqlite_error_file_load() {
+        assert_ne!(
+            Error::FileLoad("s1".to_owned()),
+            Error::FileLoad("s2".to_owned())
+        )
+    }
+
+    // Two errors with different foreign key checks should be considered different
+    #[test]
+    fn test_rusqlite_error_fkc() {
+        assert_ne!(
+            Error::ForeignKeyCheck(ForeignKeyCheckError {
+                table: "t1".to_owned(),
+                rowid: 1,
+                parent: "t2".to_owned(),
+                fkid: 3
+            }),
+            Error::ForeignKeyCheck(ForeignKeyCheckError {
+                table: "t1".to_owned(),
+                rowid: 3,
+                parent: "t2".to_owned(),
+                fkid: 3
+            },),
+        )
+    }
+
     // Hook error conversion preserves the message
     #[test]
     fn test_hook_conversion_msg() {

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -73,7 +73,8 @@ where
 
 impl Debug for Box<dyn MigrationHook> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "MigrationHook({:#x})", addr_of!(*self) as usize)
+        // Don’t print the closure address as it changes between runs
+        write!(f, "MigrationHook(<closure>)")
     }
 }
 

--- a/rusqlite_migration/src/loader.rs
+++ b/rusqlite_migration/src/loader.rs
@@ -22,6 +22,7 @@ fn get_name(value: &'static Dir<'static>) -> Result<&'static str> {
         )))
 }
 
+#[cfg_attr(test, mutants::skip)] // Tested at a high level
 fn get_migrations(
     name: &'static str,
     value: &'static Dir<'static>,
@@ -90,6 +91,7 @@ impl<'u> From<&MigrationFile> for M<'u> {
     }
 }
 
+#[cfg_attr(test, mutants::skip)] // Tested at a high level
 pub(crate) fn from_directory(dir: &'static Dir<'static>) -> Result<Vec<Option<M<'static>>>> {
     let mut migrations: Vec<Option<M>> = vec![None; dir.dirs().count()];
 

--- a/rusqlite_migration/src/tests/builder.rs
+++ b/rusqlite_migration/src/tests/builder.rs
@@ -1,6 +1,8 @@
-use std::iter::FromIterator;
+use std::{iter::FromIterator, num::NonZeroUsize};
 
-use crate::{MigrationsBuilder, M};
+use rusqlite::Connection;
+
+use crate::{Migrations, MigrationsBuilder, SchemaVersion, M};
 
 #[test]
 #[should_panic]
@@ -16,4 +18,28 @@ fn test_0_index() {
     let ms = vec![M::up("CREATE TABLE t(a);")];
 
     let _ = MigrationsBuilder::from_iter(ms).edit(0, move |t| t);
+}
+
+#[test]
+fn test_len_builder() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    // Define migrations
+    let ms = vec![
+        M::up("CREATE TABLE friend(name TEXT);"),
+        M::up("ALTER TABLE friend ADD COLUMN birthday TEXT;"),
+    ];
+
+    {
+        let builder = MigrationsBuilder::from_iter(ms);
+
+        let migrations: Migrations = builder.finalize();
+
+        migrations.to_latest(&mut conn).unwrap();
+
+        assert_eq!(migrations.ms.len(), 2);
+        assert_eq!(
+            Ok(SchemaVersion::Inside(NonZeroUsize::new(2).unwrap())),
+            migrations.current_version(&conn)
+        );
+    }
 }

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__len_builder.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__len_builder.snap
@@ -1,0 +1,24 @@
+---
+source: rusqlite_migration/src/tests/builder.rs
+expression: migrations
+---
+Migrations {
+    ms: [
+        M {
+            up: "CREATE TABLE friend(name TEXT);",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+        M {
+            up: "ALTER TABLE friend ADD COLUMN birthday TEXT;",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+    ],
+}

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__valid_index.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__valid_index.snap
@@ -1,0 +1,28 @@
+---
+source: rusqlite_migration/src/tests/builder.rs
+expression: "MigrationsBuilder::from_iter(ms).edit(1,\n            move |m|\n                m.down(\"DROP TABLE t1;\")).edit(2,\n        move |m| m.down(\"DROP TABLE t2;\")).finalize::<Migrations>()"
+---
+Migrations {
+    ms: [
+        M {
+            up: "CREATE TABLE t1(a);",
+            up_hook: None,
+            down: Some(
+                "DROP TABLE t1;",
+            ),
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+        M {
+            up: "CREATE TABLE t2(a);",
+            up_hook: None,
+            down: Some(
+                "DROP TABLE t2;",
+            ),
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+    ],
+}

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__synch__migration_hook_debug.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__synch__migration_hook_debug.snap
@@ -1,0 +1,14 @@
+---
+source: rusqlite_migration/src/tests/synch.rs
+expression: m
+---
+M {
+    up: "",
+    up_hook: Some(
+        MigrationHook(<closure>),
+    ),
+    down: None,
+    down_hook: None,
+    foreign_key_check: false,
+    comment: None,
+}

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -48,6 +48,36 @@ fn empty_migrations_test() {
 }
 
 #[test]
+fn test_db_version_to_schema_empty() {
+    let m = Migrations::new(vec![]);
+
+    assert_eq!(m.db_version_to_schema(0), SchemaVersion::NoneSet);
+    assert_eq!(
+        m.db_version_to_schema(1),
+        SchemaVersion::Outside(NonZeroUsize::new(1).unwrap())
+    );
+    assert_eq!(
+        m.db_version_to_schema(10),
+        SchemaVersion::Outside(NonZeroUsize::new(10).unwrap())
+    );
+}
+
+#[test]
+fn test_db_version_to_schema_two() {
+    let m = Migrations::new(vec![m_valid10(), m_valid11()]);
+
+    assert_eq!(m.db_version_to_schema(0), SchemaVersion::NoneSet);
+    assert_eq!(
+        m.db_version_to_schema(1),
+        SchemaVersion::Inside(NonZeroUsize::new(1).unwrap())
+    );
+    assert_eq!(
+        m.db_version_to_schema(10),
+        SchemaVersion::Outside(NonZeroUsize::new(10).unwrap())
+    );
+}
+
+#[test]
 fn schema_version_partial_cmp_test() {
     assert_eq!(SchemaVersion::NoneSet, SchemaVersion::NoneSet);
     assert_eq!(

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -85,13 +85,7 @@ fn schema_version_partial_cmp_test() {
 #[test]
 fn test_migration_hook_debug() {
     let m = M::up_with_hook("", |_: &Transaction| Ok(()));
-    assert_eq!(
-        format!(
-            r#"M {{ up: "", up_hook: {:?}, down: None, down_hook: None, foreign_key_check: false, comment: None }}"#,
-            m.up_hook
-        ),
-        format!("{m:?}")
-    );
+    insta::assert_debug_snapshot!(m);
 }
 
 #[test]


### PR DESCRIPTION
Newer versions now build on the codebase. The only issue is that there are some more mutants to catch.