### PR TITLE
Start splitting out an async package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Summing up all the changes from the previous Alpha versions.
 
 Rusqlite was updated from 0.29.0 to 0.30.0. Please see [its release notes](https://github.com/rusqlite/rusqlite/releases/tag/v0.30.0)
 
+### Breaking changes since Version 1.1.0 Alpha 3
+
+* Moved the `async-tokio-rusqlite` feature to a different crate
+
 ### Minimum Rust Version
 
 Rust 1.70

--- a/README.md
+++ b/README.md
@@ -108,10 +108,9 @@ fn migrations_test() {
 
 ## Optional Features
 
-Rusqlite_migration provides several [Cargo features][cargo_features]. They are:
+Rusqlite_migration provides one [Cargo feature][cargo_features]:
 
 * `from-directory`: enable loading migrations from *.sql files in a given directory
-* `async-tokio-rusqlite`: enable support for async migrations with `tokio-rusqlite`
 
 [cargo_features]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -14,8 +14,6 @@ rust-version = "1.70"
 
 [features]
 default = []
-### Enable support for async migrations with the use of `tokio-rusqlite`
-async-tokio-rusqlite = ["dep:tokio-rusqlite", "dep:tokio"]
 
 ### Enable loading migrations from *.sql files in a given directory
 from-directory = ["dep:include_dir"]
@@ -32,8 +30,6 @@ default-features = false
 features = []
 
 [dev-dependencies]
-tokio = { version = "1.25", features = ["full"] }
-tokio-test = "0.4.2"
 simple-logging = "2.0.2"
 env_logger = "0.10"
 anyhow = "1"

--- a/rusqlite_migration/src/errors.rs
+++ b/rusqlite_migration/src/errors.rs
@@ -95,7 +95,6 @@ impl From<rusqlite::Error> for Error {
     }
 }
 
-#[cfg(feature = "async-tokio-rusqlite")]
 impl From<tokio_rusqlite::Error> for Error {
     fn from(e: tokio_rusqlite::Error) -> Self {
         match e {

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 
 [dependencies.rusqlite_migration]
 path = "../rusqlite_migration"
-features = ["async-tokio-rusqlite", "from-directory"]
+features = ["from-directory"]
 
 [dependencies.rusqlite]
 version = "=0.30.0"

--- a/rusqlite_migration_tokio_async/Cargo.toml
+++ b/rusqlite_migration_tokio_async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusqlite_migration_tokio_async"
-version = "0.0.1-alpha1"
+version = "0.1.0"
 authors = ["Clément Joly <foss@131719.xyz>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -10,3 +10,31 @@ categories = ["database"]
 readme = "README.md"
 homepage = "https://cj.rs/rusqlite_migration"
 repository = "https://github.com/cljoly/rusqlite_migration/tree/master/rusqlite_migration_tokio_async"
+rust-version = "1.70"
+
+[features]
+default = []
+
+### Enable loading migrations from *.sql files in a given directory
+from-directory = ["dep:include_dir"]
+
+[dependencies]
+rusqlite_migration = { path = "../rusqlite_migration/", version = "1.1.0-beta.1" }
+include_dir = { version = "0.7.3", optional = true }
+tokio = { version = "1.25", features = ["macros"], optional = true }
+tokio-rusqlite = { version = "0.5.0", optional = true }
+log = "0.4"
+
+[dependencies.rusqlite]
+version = "=0.30.0"
+default-features = false
+features = []
+
+[dev-dependencies]
+tokio = { version = "1.25", features = ["full"] }
+tokio-test = "0.4.2"
+simple-logging = "2.0.2"
+env_logger = "0.10"
+anyhow = "1"
+lazy_static = "1.4.0"
+mktemp = "0.5"


### PR DESCRIPTION
Unfortunately, if we did that, we would lose the ability to have common types (in particular for errors.)