### PR TITLE
Don't pin to exact rusqlite version

### DIFF
--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -17,6 +17,6 @@ mktemp = "0.5"
 include_dir = "0.7.3"
 
 [dependencies.rusqlite]
-version = "=0.30.0"
+version = "0.30.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -14,6 +14,6 @@ lazy_static = "1.4.0"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "=0.30.0"
+version = "0.30.0"
 default-features = false
 features = []

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -27,7 +27,7 @@ tokio-rusqlite = { version = "0.5.0", optional = true }
 log = "0.4"
 
 [dependencies.rusqlite]
-version = "=0.30.0"
+version = "0.30.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -23,7 +23,7 @@ path = "../rusqlite_migration"
 features = ["async-tokio-rusqlite", "from-directory"]
 
 [dependencies.rusqlite]
-version = "=0.30.0"
+version = "0.30.0"
 default-features = false
 features = []
 


### PR DESCRIPTION
Pinning the dependency to the exact version `0.30.0` is unnecessary because Cargo doesn't consider 0.30 and 0.31 compatible (Cargo's modified semver considers the first non-zero component of the version as the "major" number that determines compatibility). In addition, pinning to an exact version can prevent an update to an in-theory-compatible 0.30.1 and even cause unresolvable dependency conflicts in downstream packages. To be fair however, rusqlite doesn't seem to use the patch component of the version number anyway so this wouldn't happen in practice.