### PR TITLE
Update Cargo.toml files to use recent features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.2.0 Alpha 1
+
+### Minimum Rust Version
+
+Now using edition 2021
+
 ## Version 1.1.0
 
 *Same code as version 1.1.0-beta.1*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ members = [
 
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 resolver = "2"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rusqlite_migration"
-version = "1.1.0"
+version = "1.2.0-alpha.1"
 authors = ["Clément Joly <foss@131719.xyz>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."
 keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -19,6 +19,9 @@ rust-version = "1.70"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints]
+workspace = true
+
 [features]
 default = []
 ### Enable support for async migrations with the use of `tokio-rusqlite`

--- a/rusqlite_migration/benches/criterion.rs
+++ b/rusqlite_migration/benches/criterion.rs
@@ -14,6 +14,8 @@ limitations under the License.
 
 */
 
+//! Benchmarks using criterion
+
 use criterion::criterion_main;
 
 #[cfg(feature = "from-directory")]

--- a/rusqlite_migration/benches/iai.rs
+++ b/rusqlite_migration/benches/iai.rs
@@ -14,14 +14,14 @@ limitations under the License.
 
 */
 
+//! Why criterion and iai? It’s actually recommended:
+//! https://bheisler.github.io/criterion.rs/book/iai/comparison.html
+
 use std::iter::FromIterator;
 
 use iai::black_box;
 use rusqlite::Connection;
 use rusqlite_migration::{Migrations, M};
-
-// Why criterion and iai? It’s actually recommended:
-// https://bheisler.github.io/criterion.rs/book/iai/comparison.html
 
 fn upward(i: u64) {
     let sql_migrations = (0..=i)

--- a/rusqlite_migration/build.rs
+++ b/rusqlite_migration/build.rs
@@ -1,3 +1,5 @@
+//! Insert the readme as documentation of the crate
+
 use std::{
     env,
     error::Error,

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![forbid(unsafe_code)]
-#![warn(missing_docs)]
 // The doc is extracted from the README.md file at build time
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/readme_for_rustdoc.md"))]
 

--- a/rusqlite_migration_tokio_async/Cargo.toml
+++ b/rusqlite_migration_tokio_async/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rusqlite_migration_tokio_async"
 version = "0.0.1-alpha1"
 authors = ["Clément Joly <foss@131719.xyz>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."
 keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
@@ -10,3 +10,7 @@ categories = ["database"]
 readme = "README.md"
 homepage = "https://cj.rs/rusqlite_migration"
 repository = "https://github.com/cljoly/rusqlite_migration/tree/master/rusqlite_migration_tokio_async"
+
+[lints]
+workspace = true
+

--- a/rusqlite_migration_tokio_async/src/lib.rs
+++ b/rusqlite_migration_tokio_async/src/lib.rs
@@ -1,3 +1,6 @@
+//! Might eventually hold the async code
+
+/// Add
 pub fn add(left: usize, right: usize) -> usize {
     left + right
 }


### PR DESCRIPTION
- Bump edition to 2021
- Refresh cargo manifests (in particular, factor out linter directives)
