### PR TITLE
chore: update cargo-mutants to version 24.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,11 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install --version 23.12.0 cargo-mutants
+      - run: cargo install --locked cargo-mutants
       - uses: actions-rs/cargo@v1
         with:
           command: mutants
+          args: --colors=always
       - name: Archive results
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
Use the newly introduced feature to force color output in CI. More
enhancements (e.g. [sharding][1]) may be implemented in the future.

Now that Cargo.lock is committed, install cargo-mutants based on the
content of the lock file.

[1]: https://mutants.rs/shards.html?highlight=shard#sharding

