### PR TITLE
Rusqlite update to latest version (0.31)

### DIFF
--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -37,7 +37,7 @@ tokio-rusqlite = { version = "0.5.0", optional = true }
 log = "0.4"
 
 [dependencies.rusqlite]
-version = "0.30.0"
+version = "0.31.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -23,7 +23,7 @@ path = "../rusqlite_migration"
 features = ["alpha-async-tokio-rusqlite", "from-directory"]
 
 [dependencies.rusqlite]
-version = "0.30.0"
+version = "0.31.0"
 default-features = false
 features = []
 


### PR DESCRIPTION
Updates the version of `rusqlite` used to `0.31`. Usually this would not be a big deal, but the shipped version of `libsqlite3` has been updated to `0.28`, which conflicts with the version `0.27` shipped with `rusqlite 0.30`.

This is the error caused by the conflict:
```
rust-analyzer failed to load workspace: Failed to load the project at /home/lenndg/projects/quickplan/server/Cargo.toml: Failed to read Cargo metadata from Cargo.toml file /home/lenndg/projects/quickplan/server/Cargo.toml, Some(Version { major: 1, minor: 76, patch: 0 }): Failed to run `cd "/home/lenndg/projects/quickplan/server" && RUSTUP_TOOLCHAIN="/home/lenndg/.rustup/toolchains/stable-x86_64-unknown-linux-gnu" "/home/lenndg/.cargo/bin/cargo" "metadata" "--format-version" "1" "--manifest-path" "/home/lenndg/projects/quickplan/server/Cargo.toml" "--filter-platform" "x86_64-unknown-linux-gnu"`: `cargo metadata` exited with an error:     Blocking waiting for file lock on package cache
    Updating crates.io index
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `rusqlite v0.30.0`
    ... which satisfies dependency `rusqlite = "^0.30.0"` of package `rusqlite_migration v1.1.0`
    ... which satisfies dependency `rusqlite_migration = "^1.1.0"` of package `lib-core v0.1.0 (/home/lenndg/projects/quickplan/server/crates/libs/lib-core)`
    ... which satisfies path dependency `lib-core` (locked to 0.1.0) of package `web-server v0.1.0 (/home/lenndg/projects/quickplan/server/crates/services/web-server)`
versions that meet the requirements `^0.27.0` are: 0.27.0

the package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:
package `libsqlite3-sys v0.28.0`
    ... which satisfies dependency `libsqlite3-sys = "^0.28.0"` of package `rusqlite v0.31.0`
    ... which satisfies dependency `rusqlite = "^0.31"` of package `lib-core v0.1.0 (/home/lenndg/projects/quickplan/server/crates/libs/lib-core)`
    ... which satisfies path dependency `lib-core` (locked to 0.1.0) of package `web-server v0.1.0 (/home/lenndg/projects/quickplan/server/crates/services/web-server)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "sqlite3"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsqlite3-sys` which could resolve this conflict
```

