### PR TITLE
Fix broken docs and examples when some rusqlite features are used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: mutants
-          args: --colors=always --no-shuffle -vV --shard ${{ matrix.shard }}/4
+          args: -p rusqlite_migration --colors=always --no-shuffle -vV --shard ${{ matrix.shard }}/4
       - name: Archive results
         uses: actions/upload-artifact@v3
         if: failure()
@@ -166,8 +166,8 @@ jobs:
           name: mutation-report
           path: mutants.out
 
-  clippy:
-    name: Clippy
+  clippy_all:
+    name: Clippy (all code)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -181,7 +181,25 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc -D clippy::doc_link_with_quotes -D clippy::doc_markdown
+          args: --all-features -- -D warnings
+
+  clippy_main:
+    name: Clippy (main package)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          # More stringent requirements
+          args: --all-features -p rusqlite_migration -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc -D clippy::doc_link_with_quotes -D clippy::doc_markdown
 
   coverage:
     name: Code coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-async"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "mktemp",
+ "rusqlite",
+ "rusqlite_migration",
+ "simple-logging",
+ "tokio",
+ "tokio-rusqlite",
+]
+
+[[package]]
+name = "example-from-directory"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "include_dir",
+ "lazy_static",
+ "log",
+ "mktemp",
+ "rusqlite",
+ "rusqlite_migration",
+ "simple-logging",
+]
+
+[[package]]
+name = "example-simple"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "mktemp",
+ "rusqlite",
+ "rusqlite_migration",
+ "simple-logging",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
 dependencies = [
  "hashbrown",
 ]
@@ -487,9 +532,9 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -760,9 +805,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rusqlite"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags 2.4.1",
  "fallible-iterator",
@@ -774,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "1.1.0"
+version = "1.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1001,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc785c98d0c872455381e59be1f33a8f3a6b4e852544212e37601cc2ccb21d39"
+checksum = "c2cc5f712424f089fc6549afe39773e9f8914ce170c45b546be24830b482b127"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "rusqlite_migration",
   "rusqlite_migration_tokio_async",
   "rusqlite_migration_tests",
+  "examples/*",
 ]
 
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ let migrations = Migrations::new(vec![
 let mut conn = Connection::open_in_memory().unwrap();
 
 // Apply some PRAGMA, often better to do it outside of migrations
-conn.pragma_update(None, "journal_mode", &"WAL").unwrap();
+conn.pragma_update_and_check(None, "journal_mode", &"WAL", |_| Ok(())).unwrap();
 
 // 2️⃣ Update the database schema, atomically
 migrations.to_latest(&mut conn).unwrap();

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,0 @@
-[workspace]
-members = ["*"]
-exclude = ["target"]
-resolver = "2"
-

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -19,6 +19,6 @@ path = "../../rusqlite_migration"
 features = ["alpha-async-tokio-rusqlite"]
 
 [dependencies.rusqlite]
-version = "=0.30.0"
+version = "=0.31.0"
 default-features = false
 features = []

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -56,28 +56,32 @@ async fn main() {
     // executed for each connection (like `foreign_keys`) or to be executed outside transactions
     // (`journal_mode` is a noop in a transaction).
     async_conn
-        .call(|conn| conn.pragma_update(None, "journal_mode", "WAL"))
+        .call(|conn| Ok(conn.pragma_update(None, "journal_mode", "WAL")))
         .await
+        .unwrap()
         .unwrap();
     async_conn
-        .call(|conn| conn.pragma_update(None, "foreign_keys", "ON"))
+        .call(|conn| Ok(conn.pragma_update(None, "foreign_keys", "ON")))
         .await
+        .unwrap()
         .unwrap();
 
     // Use the db 🥳
     async_conn
         .call(|conn| {
-            conn.execute(
+            Ok(conn.execute(
                 "INSERT INTO friend (name, birthday) VALUES (?1, ?2)",
                 params!["John", "1970-01-01"],
-            )
+            ))
         })
         .await
+        .unwrap()
         .unwrap();
 
     async_conn
-        .call(|conn| conn.execute("INSERT INTO animal (name) VALUES (?1)", params!["dog"]))
+        .call(|conn| Ok(conn.execute("INSERT INTO animal (name) VALUES (?1)", params!["dog"])))
         .await
+        .unwrap()
         .unwrap();
 
     // If we want to revert the last migration
@@ -85,7 +89,7 @@ async fn main() {
 
     // The table was removed
     async_conn
-        .call(|conn| conn.execute("INSERT INTO animal (name) VALUES (?1)", params!["cat"]))
+        .call(|conn| Ok(conn.execute("INSERT INTO animal (name) VALUES (?1)", params!["cat"])))
         .await
         .unwrap_err();
 }

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -17,6 +17,6 @@ mktemp = "0.5"
 include_dir = "0.7.3"
 
 [dependencies.rusqlite]
-version = "0.30.0"
+version = "0.31.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -14,6 +14,5 @@ lazy_static = "1.4.0"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "0.30.0"
-default-features = false
-features = []
+version = "0.31.0"
+features = ["extra_check"] # A realistic use case

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -285,7 +285,6 @@ impl<'u> M<'u> {
     ///
     /// // Turn foreign key constraints off for the duration of the migration
     /// conn.pragma_update(None, "foreign_keys", &"OFF").unwrap();
-    /// conn.pragma_update(None, "journal_mode", &"WAL").unwrap();
     ///
     /// migrations.to_latest(&mut conn).unwrap();
     ///

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -24,8 +24,7 @@ features = ["alpha-async-tokio-rusqlite", "from-directory"]
 
 [dependencies.rusqlite]
 version = "0.31.0"
-default-features = false
-features = []
+features = ["extra_check"]
 
 [dev-dependencies]
 tokio-test = "0.4.2"


### PR DESCRIPTION
WIP PR to fix the problem raised in https://github.com/cljoly/rusqlite_migration/issues/15#issuecomment-1868524798:

> Hi there, first of all thanks for your work!
> I just stumbled across this line on the top level documentation of the crate:
> 
> conn.pragma_update(None, "journal_mode", &"WAL").unwrap();
> 
> This panics for me with ExecuteReturnedResults. According to this issue in rusqlite we have to use pragma_update_and_check instead.
> 
> So probably the easiest way to fix the documentation would be to change that line to:
> conn.pragma_update_and_check(None, "journal_mode", &"WAL", |_| Ok(())).unwrap();
