### PR TITLE
test: add tests to catch 2 mutants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
   mutation-tests:
     name: Mutation tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -155,7 +158,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: mutants
-          args: --colors=always
+          args: --colors=always --no-shuffle -vV --shard ${{ matrix.shard }}/4
       - name: Archive results
         uses: actions/upload-artifact@v3
         if: failure()

--- a/rusqlite_migration_tokio_async/src/lib.rs
+++ b/rusqlite_migration_tokio_async/src/lib.rs
@@ -8,7 +8,7 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+        let result = add(2, 5);
+        assert_eq!(result, 7);
     }
 }


### PR DESCRIPTION
The mutants were:
```
MISSED   rusqlite_migration_tokio_async/src/lib.rs:2:10: replace + with * in add in 0.2s build + 0.1s test
MISSED   rusqlite_migration/src/lib.rs:535:35: replace - with + in Migrations<'m>::goto_down in 0.9s build + 1.5s test
```

While we are here, shard mutants to avoid waiting for too long on CI.
