### PR TITLE
chore: clean-up Cargo.toml

### DIFF
--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -5,9 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-rusqlite_migration = { path = "../../rusqlite_migration", features = [
-    "from-directory",
-] }
 log = "0.4"
 simple-logging = "2.0.2"
 env_logger = "0.10"
@@ -15,6 +12,10 @@ anyhow = "1"
 lazy_static = "1.5.0"
 mktemp = "0.5"
 include_dir = "0.7.4"
+
+[dependencies.rusqlite_migration]
+path = "../../rusqlite_migration"
+features = ["from-directory"]
 
 [dependencies.rusqlite]
 version = "0.31.0"

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -32,9 +32,13 @@ from-directory = ["dep:include_dir"]
 
 [dependencies]
 include_dir = { version = "0.7.4", optional = true }
-tokio = { version = "1.38", features = ["macros"], optional = true }
-tokio-rusqlite = { version = "0.5.0", optional = true }
 log = "0.4"
+tokio-rusqlite = { version = "0.5.0", optional = true }
+
+[dependencies.tokio]
+version = "1.38"
+features = ["macros"]
+optional = true
 
 [dependencies.rusqlite]
 version = "0.31.0"
@@ -42,20 +46,20 @@ default-features = false
 features = []
 
 [dev-dependencies]
-tokio = { version = "1.38", features = ["full"] }
-tokio-test = "0.4.4"
-simple-logging = "2.0.2"
-env_logger = "0.10"
 anyhow = "1"
-lazy_static = "1.5.0"
-mktemp = "0.5"
-criterion = { version = "0.5.0", features = [
-  "html_reports",
-  "cargo_bench_support",
-] }
+env_logger = "0.10"
 iai = "0.1"
 insta = "1.39.0"
+lazy_static = "1.5.0"
+mktemp = "0.5"
 mutants = "0.0.3"
+simple-logging = "2.0.2"
+tokio = { version = "1.38", features = ["full"] }
+tokio-test = "0.4.4"
+
+[dev-dependencies.criterion]
+version = "0.5.0"
+features = ["html_reports", "cargo_bench_support"]
 
 [[bench]]
 name = "criterion"


### PR DESCRIPTION
- Sort dependencies
- Transform multi-line inline table into tables, as the spec requires
  for readability [1]:
  > Inline tables are intended to appear on a single line. […] No
  > newlines are allowed between the curly braces unless they are valid
  > within a value. Even so, it is strongly discouraged to break an
  > inline table onto multiples lines. If you find yourself gripped
  > with this desire, it means you should be using standard tables.

[1] https://toml.io/en/v1.0.0#inline-table
