### PR TITLE
Make fn `Migrations::max_schema_version` public.

### DIFF
--- a/rusqlite_migration/src/asynch.rs
+++ b/rusqlite_migration/src/asynch.rs
@@ -158,6 +158,7 @@ impl AsyncMigrations {
 
     /// Asynchronous version of the same method in the
     /// [Migrations](crate::Migrations::is_latest_schema_version) struct.
+    #[allow(clippy::missing_errors_doc)]
     pub async fn is_latest_schema_version(&self, async_conn: &AsyncConnection) -> Result<bool> {
         let m = self.migrations.clone();
 

--- a/rusqlite_migration/src/asynch.rs
+++ b/rusqlite_migration/src/asynch.rs
@@ -150,6 +150,12 @@ impl AsyncMigrations {
             .await?
     }
 
+    /// Asynchronous version of the same method in the
+    /// [Migrations](crate::Migrations::max_schema_version) struct.
+    pub fn max_schema_version(&self) -> SchemaVersion {
+        self.migrations.max_schema_version()
+    }
+
     /// Asynchronous version of the same method in the [Migrations](crate::Migrations::validate) struct.
     ///
     /// # Example

--- a/rusqlite_migration/src/asynch.rs
+++ b/rusqlite_migration/src/asynch.rs
@@ -162,8 +162,9 @@ impl AsyncMigrations {
     pub async fn is_latest_schema_version(&self, async_conn: &AsyncConnection) -> Result<bool> {
         let m = self.migrations.clone();
 
-        async_conn.call(move |conn| Ok(m.is_latest_schema_version(conn)))
-                  .await?
+        async_conn
+            .call(move |conn| Ok(m.is_latest_schema_version(conn)))
+            .await?
     }
 
     /// Asynchronous version of the same method in the [Migrations](crate::Migrations::validate) struct.

--- a/rusqlite_migration/src/asynch.rs
+++ b/rusqlite_migration/src/asynch.rs
@@ -150,10 +150,19 @@ impl AsyncMigrations {
             .await?
     }
 
+    /// Proxy version of the same method in the
+    /// [Migrations](crate::Migrations::latest_schema_version) struct.
+    pub fn latest_schema_version(&self) -> usize {
+        self.migrations.latest_schema_version()
+    }
+
     /// Asynchronous version of the same method in the
-    /// [Migrations](crate::Migrations::max_schema_version) struct.
-    pub fn max_schema_version(&self) -> SchemaVersion {
-        self.migrations.max_schema_version()
+    /// [Migrations](crate::Migrations::is_latest_schema_version) struct.
+    pub async fn is_latest_schema_version(&self, async_conn: &AsyncConnection) -> Result<bool> {
+        let m = self.migrations.clone();
+
+        async_conn.call(move |conn| Ok(m.is_latest_schema_version(conn)))
+                  .await?
     }
 
     /// Asynchronous version of the same method in the [Migrations](crate::Migrations::validate) struct.

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -611,7 +611,8 @@ impl<'m> Migrations<'m> {
         match self.ms.len() {
             0 => SchemaVersion::NoneSet,
             v => SchemaVersion::Inside(
-                NonZeroUsize::new(v).expect("Already checked for 0 in previous match arm"),
+                NonZeroUsize::new(v)
+                    .unwrap_or_else(|| unreachable!("Already checked for 0 in previous match arm")),
             ),
         }
     }

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -697,7 +697,7 @@ impl<'m> Migrations<'m> {
                 Err(Error::MigrationDefinition(
                     MigrationDefinitionError::NoMigrationsDefined,
                 ))
-            },
+            }
             v => {
                 debug!("some migrations defined (version: {v}), try to migrate");
                 self.goto(conn, v)
@@ -754,7 +754,7 @@ impl<'m> Migrations<'m> {
                 Err(Error::MigrationDefinition(
                     MigrationDefinitionError::NoMigrationsDefined,
                 ))
-            },
+            }
             v_max => {
                 debug!("some migrations defined (version: {v_max}), try to migrate");
                 if version > v_max {
@@ -764,14 +764,12 @@ impl<'m> Migrations<'m> {
                     let highest: SchemaVersion = self.db_version_to_schema(v_max);
 
                     return Err(Error::SpecifiedSchemaVersion(
-                        SchemaVersionError::TargetVersionOutOfRange {
-                            highest, specified,
-                        },
+                        SchemaVersionError::TargetVersionOutOfRange { highest, specified },
                     ));
                 }
 
                 self.goto(conn, version)
-            },
+            }
         }
     }
 

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -619,6 +619,10 @@ impl<'m> Migrations<'m> {
     /// [`Migrations::to_latest`], which already checks the schema version.
     ///
     /// See also: [`Migrations::latest_schema_version`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RusqliteError`] in case the user version cannot be queried.
     pub fn is_latest_schema_version(&self, conn: &Connection) -> Result<bool> {
         let curr_v = user_version(conn)?;
         Ok(self.latest_schema_version() == curr_v)

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -601,7 +601,7 @@ impl<'m> Migrations<'m> {
     }
 
     /// Maximum version defined in the migration set
-    fn max_schema_version(&self) -> SchemaVersion {
+    pub fn max_schema_version(&self) -> SchemaVersion {
         match self.ms.len() {
             0 => SchemaVersion::NoneSet,
             v => SchemaVersion::Inside(

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -600,8 +600,13 @@ impl<'m> Migrations<'m> {
         res
     }
 
-    /// Maximum version defined in the migration set
-    #[allow(clippy::missing_panics_doc)]
+    /// Return the maximum version defined in the migration set.
+    ///
+    /// If you are using [`Migrations::from_directory()`] and `include_dir!`, it is non-trivial to
+    /// access the number of migrations loaded, so you may need to use this method.
+    ///
+    /// For the most common scenarios though, you should be able to just call
+    /// [`Migrations::to_latest`].
     pub fn max_schema_version(&self) -> SchemaVersion {
         match self.ms.len() {
             0 => SchemaVersion::NoneSet,

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -606,7 +606,8 @@ impl<'m> Migrations<'m> {
         match self.ms.len() {
             0 => SchemaVersion::NoneSet,
             v => SchemaVersion::Inside(
-                NonZeroUsize::new(v).expect("Already checked for 0 in previous match arm")),
+                NonZeroUsize::new(v).expect("Already checked for 0 in previous match arm"),
+            ),
         }
     }
 

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -601,12 +601,12 @@ impl<'m> Migrations<'m> {
     }
 
     /// Maximum version defined in the migration set
+    #[allow(clippy::missing_panics_doc)]
     pub fn max_schema_version(&self) -> SchemaVersion {
         match self.ms.len() {
             0 => SchemaVersion::NoneSet,
             v => SchemaVersion::Inside(
-                NonZeroUsize::new(v).expect("schema version should not be equal to 0"),
-            ),
+                NonZeroUsize::new(v).expect("Already checked for 0 in previous match arm")),
         }
     }
 

--- a/rusqlite_migration/src/tests/asynch.rs
+++ b/rusqlite_migration/src/tests/asynch.rs
@@ -5,7 +5,7 @@ use crate::{
         all_valid, m_invalid0, m_invalid1, m_invalid_down_fk, m_invalid_fk, m_valid0, m_valid10,
         m_valid11, m_valid20, m_valid21, m_valid_fk,
     },
-    AsyncMigrations, Error, MigrationDefinitionError
+    AsyncMigrations, Error, MigrationDefinitionError,
 };
 use tokio_rusqlite::Connection as AsyncConnection;
 

--- a/rusqlite_migration/src/tests/asynch.rs
+++ b/rusqlite_migration/src/tests/asynch.rs
@@ -84,14 +84,20 @@ async fn current_version_gt_max_schema_version_async_test() {
         migrations.to_latest(&mut conn).await.unwrap();
 
         // After to_latest
-        assert_eq!(2_usize, migrations.current_version(&conn).await.unwrap().into());
+        assert_eq!(
+            2_usize,
+            migrations.current_version(&conn).await.unwrap().into()
+        );
         assert_eq!(Ok(true), migrations.is_latest_schema_version(&conn).await);
     }
 
     // We now have fewer migrations
     let migrations = AsyncMigrations::new(vec![m_valid0()]);
     assert_eq!(1, migrations.latest_schema_version());
-    assert_eq!(2_usize, migrations.current_version(&conn).await.unwrap().into());
+    assert_eq!(
+        2_usize,
+        migrations.current_version(&conn).await.unwrap().into()
+    );
 
     assert_eq!(Ok(false), migrations.is_latest_schema_version(&conn).await);
 

--- a/rusqlite_migration/src/tests/asynch.rs
+++ b/rusqlite_migration/src/tests/asynch.rs
@@ -1,11 +1,11 @@
-use std::{iter::FromIterator, num::NonZeroUsize};
+use std::iter::FromIterator;
 
 use crate::{
     tests::helpers::{
         all_valid, m_invalid0, m_invalid1, m_invalid_down_fk, m_invalid_fk, m_valid0, m_valid10,
         m_valid11, m_valid20, m_valid21, m_valid_fk,
     },
-    AsyncMigrations, Error, MigrationDefinitionError, SchemaVersion,
+    AsyncMigrations, Error, MigrationDefinitionError
 };
 use tokio_rusqlite::Connection as AsyncConnection;
 
@@ -76,19 +76,15 @@ async fn current_version_gt_max_schema_version_async_test() {
     // Set migrations to a higher number
     {
         let migrations = AsyncMigrations::new(vec![m_valid0(), m_valid10()]);
-        assert_eq!(
-            SchemaVersion::Inside(NonZeroUsize::new(2).unwrap()),
-            migrations.max_schema_version()
-        );
+        assert_eq!(2, migrations.latest_schema_version());
         migrations.to_latest(&mut conn).await.unwrap();
     }
 
     // We now have fewer migrations
     let migrations = AsyncMigrations::new(vec![m_valid0()]);
-    assert_eq!(
-        SchemaVersion::Inside(NonZeroUsize::new(1).unwrap()),
-        migrations.max_schema_version()
-    );
+    assert_eq!(1, migrations.latest_schema_version());
+
+    assert_eq!(Ok(false), migrations.is_latest_schema_version(&conn).await);
 
     // We should get an error
     assert_eq!(

--- a/rusqlite_migration/src/tests/asynch.rs
+++ b/rusqlite_migration/src/tests/asynch.rs
@@ -76,13 +76,22 @@ async fn current_version_gt_max_schema_version_async_test() {
     // Set migrations to a higher number
     {
         let migrations = AsyncMigrations::new(vec![m_valid0(), m_valid10()]);
+
+        // Before to_latest.
         assert_eq!(2, migrations.latest_schema_version());
+        assert_eq!(Ok(false), migrations.is_latest_schema_version(&conn).await);
+
         migrations.to_latest(&mut conn).await.unwrap();
+
+        // After to_latest
+        assert_eq!(2_usize, migrations.current_version(&conn).await.unwrap().into());
+        assert_eq!(Ok(true), migrations.is_latest_schema_version(&conn).await);
     }
 
     // We now have fewer migrations
     let migrations = AsyncMigrations::new(vec![m_valid0()]);
     assert_eq!(1, migrations.latest_schema_version());
+    assert_eq!(2_usize, migrations.current_version(&conn).await.unwrap().into());
 
     assert_eq!(Ok(false), migrations.is_latest_schema_version(&conn).await);
 

--- a/rusqlite_migration/src/tests/asynch.rs
+++ b/rusqlite_migration/src/tests/asynch.rs
@@ -1,11 +1,11 @@
-use std::iter::FromIterator;
+use std::{iter::FromIterator, num::NonZeroUsize};
 
 use crate::{
     tests::helpers::{
         all_valid, m_invalid0, m_invalid1, m_invalid_down_fk, m_invalid_fk, m_valid0, m_valid10,
         m_valid11, m_valid20, m_valid21, m_valid_fk,
     },
-    AsyncMigrations, Error, MigrationDefinitionError,
+    AsyncMigrations, Error, MigrationDefinitionError, SchemaVersion,
 };
 use tokio_rusqlite::Connection as AsyncConnection;
 
@@ -76,11 +76,19 @@ async fn current_version_gt_max_schema_version_async_test() {
     // Set migrations to a higher number
     {
         let migrations = AsyncMigrations::new(vec![m_valid0(), m_valid10()]);
+        assert_eq!(
+            SchemaVersion::Inside(NonZeroUsize::new(2).unwrap()),
+            migrations.max_schema_version()
+        );
         migrations.to_latest(&mut conn).await.unwrap();
     }
 
-    // We now have less migrations
+    // We now have fewer migrations
     let migrations = AsyncMigrations::new(vec![m_valid0()]);
+    assert_eq!(
+        SchemaVersion::Inside(NonZeroUsize::new(1).unwrap()),
+        migrations.max_schema_version()
+    );
 
     // We should get an error
     assert_eq!(

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -270,6 +270,10 @@ fn user_version_migrate_test() {
         Ok(SchemaVersion::Inside(NonZeroUsize::new(1).unwrap())),
         migrations.current_version(&conn)
     );
+    assert_eq!(
+        SchemaVersion::Inside(NonZeroUsize::new(1).unwrap()),
+        migrations.max_schema_version()
+    );
 
     let migrations = Migrations::new(vec![m_valid10(), m_valid11()]);
     assert_eq!(Ok(()), migrations.to_latest(&mut conn));
@@ -277,6 +281,10 @@ fn user_version_migrate_test() {
     assert_eq!(
         Ok(SchemaVersion::Inside(NonZeroUsize::new(2).unwrap())),
         migrations.current_version(&conn)
+    );
+    assert_eq!(
+        SchemaVersion::Inside(NonZeroUsize::new(2).unwrap()),
+        migrations.max_schema_version()
     );
 }
 

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -270,22 +270,24 @@ fn user_version_migrate_test() {
         Ok(SchemaVersion::Inside(NonZeroUsize::new(1).unwrap())),
         migrations.current_version(&conn)
     );
-    assert_eq!(
-        SchemaVersion::Inside(NonZeroUsize::new(1).unwrap()),
-        migrations.max_schema_version()
-    );
+    assert_eq!(1, migrations.latest_schema_version());
+    assert_eq!(Ok(true), migrations.is_latest_schema_version(&conn));
 
     let migrations = Migrations::new(vec![m_valid10(), m_valid11()]);
+
+    // Before to_latest
+    assert_eq!(2, migrations.latest_schema_version());
+    assert_eq!(Ok(false), migrations.is_latest_schema_version(&conn));
+
     assert_eq!(Ok(()), migrations.to_latest(&mut conn));
+
+    // After to_latest
     assert_eq!(Ok(2), user_version(&conn));
     assert_eq!(
         Ok(SchemaVersion::Inside(NonZeroUsize::new(2).unwrap())),
         migrations.current_version(&conn)
     );
-    assert_eq!(
-        SchemaVersion::Inside(NonZeroUsize::new(2).unwrap()),
-        migrations.max_schema_version()
-    );
+    assert_eq!(Ok(true), migrations.is_latest_schema_version(&conn));
 }
 
 #[test]


### PR DESCRIPTION
Addresses #170 

[`fn Migrations::max_schema_version(&self)`](https://docs.rs/rusqlite_migration/1.2.0/src/rusqlite_migration/lib.rs.html#603-611) is a currently private method that returns the number of available migrations wrapped in SchemaVersion.

I would like access to this value in my own code. I'm using `Migrations::from_directory()` and `include_dir!` to construct my Migrations, so getting the count myself is non-trivial AFAICT.

My use case is to work out whether any migrations will be run by `fn Migrations::to_latest()` before running it, and if so to take a backup first.

The library code change is effectively 1 line (1 more to disable a clippy lint on the now-public method, 1 more to improve documentation IMO). Since this adds a new method to the public API I put 2 asserts into an existing test to avoid regressions.