### PR TITLE
chore! Update rusqlite to v0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,8 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite"
-version = "0.5.1"
-source = "git+https://github.com/programatik29/tokio-rusqlite.git#d101d1cb32f462f76b7c639d351e6fcf56528004"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65501378eb676f400c57991f42cbd0986827ab5c5200c53f206d710fb32a945"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,9 +596,9 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -860,9 +860,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "1cdbe9230a57259b37f7257d0aff38b8c9dbda3513edba2105e59b130189d82f"
 dependencies = [
  "bitflags 2.4.1",
  "fallible-iterator",
@@ -1092,8 +1092,7 @@ dependencies = [
 [[package]]
 name = "tokio-rusqlite"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2cc5f712424f089fc6549afe39773e9f8914ce170c45b546be24830b482b127"
+source = "git+https://github.com/programatik29/tokio-rusqlite.git#d101d1cb32f462f76b7c639d351e6fcf56528004"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ members = [
   "rusqlite_migration_tests",
   "examples/*",
 ]
-
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 resolver = "2"
+
+[patch.crates-io]
+tokio-rusqlite = { git = "https://github.com/programatik29/tokio-rusqlite.git" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ members = [
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 resolver = "2"
 
-[patch.crates-io]
-tokio-rusqlite = { git = "https://github.com/programatik29/tokio-rusqlite.git" }
-
 [workspace.lints.rust]
 unsafe_code = "forbid"
 missing_docs = "warn"

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.11"
 anyhow = "1"
 lazy_static = "1.5.0"
 mktemp = "0.5"
-tokio-rusqlite = "0.5.0"
+tokio-rusqlite = "0.6.0"
 tokio = { version = "1.40.0", features = ["full"] }
 
 [dependencies.rusqlite_migration]

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -19,6 +19,6 @@ path = "../../rusqlite_migration"
 features = ["alpha-async-tokio-rusqlite"]
 
 [dependencies.rusqlite]
-version = "=0.31.0"
+version = "=0.32.0"
 default-features = false
 features = []

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -18,6 +18,6 @@ path = "../../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.31.0"
+version = "0.32.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -14,5 +14,5 @@ lazy_static = "1.5.0"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "0.31.0"
+version = "0.32.0"
 features = ["extra_check"] # A realistic use case

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -34,7 +34,7 @@ from-directory = ["dep:include_dir"]
 [dependencies]
 include_dir = { version = "0.7.4", optional = true }
 log = "0.4"
-tokio-rusqlite = { version = "0.5.0", optional = true }
+tokio-rusqlite = { version = "0.6.0", optional = true }
 
 [dependencies.tokio]
 version = "1.40"

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -42,7 +42,7 @@ features = ["macros"]
 optional = true
 
 [dependencies.rusqlite]
-version = "0.31.0"
+version = "0.32.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -658,6 +658,19 @@ impl<'m> Migrations<'m> {
     /// ```
     /// If rusqlite `extra_check` feature is enabled, any migration that returns a value will error
     /// and no further migrations will be applied.
+    ///
+    /// # Transaction Behavior
+    ///
+    /// Since rusqlite 0.33, a [default transaction behavior][default_behavior] can be set. For
+    /// now, when applying migrations, this setting will be respected.
+    ///
+    /// Please note that future minor versions of rusqlite_migration might decide to ignore the
+    /// setting and to instead use any transaction behavior deemed most appropriate.  You can read
+    /// more in the [corresponding page of the SQLite documentation][sqlite_doc].
+    ///
+    ///
+    /// [default_behavior]: https://github.com/rusqlite/rusqlite/pull/1532
+    /// [sqlite_doc]: https://sqlite.org/lang_transaction.html
     pub fn to_latest(&self, conn: &mut Connection) -> Result<()> {
         let v_max = self.max_schema_version();
         match v_max {

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -24,7 +24,7 @@ path = "../rusqlite_migration"
 features = ["alpha-async-tokio-rusqlite", "from-directory"]
 
 [dependencies.rusqlite]
-version = "0.31.0"
+version = "0.32.0"
 features = ["extra_check"]
 
 [dev-dependencies]

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -16,7 +16,7 @@ version.workspace = true
 
 [dependencies]
 tokio = { version = "1.40", features = ["macros"] }
-tokio-rusqlite = { version = "0.5.0" }
+tokio-rusqlite = { version = "0.6.0" }
 log = "0.4"
 
 [dependencies.rusqlite_migration]


### PR DESCRIPTION
This PR aims to introduce a long term solution to update rusqlite to v0.33. If you need an updated version now, there is a stopgap [alpha version](https://github.com/cljoly/rusqlite_migration/releases/tag/v1.3.0-alpha-without-tokio.1) that you might be able to use.

******************

Changelog at https://github.com/rusqlite/rusqlite/releases/tag/v0.32.0

Concerns:
* [X] https://github.com/rusqlite/rusqlite/pull/1532/: does this mean that
  default transaction behavior can interfer with the migrations?
  * Yes, but I don’t think it matters, because all behaviors can work. Presumably, if someone uses a particular behaviors, they want it to apply also for migrations.
* [x] Update tokio-rusqlite, once a new version is ready: https://github.com/programatik29/tokio-rusqlite/pull/34
* [X] Update Changelog to prepare for the release #182 
* [X] Bump MSRV if needed and see if that unlocks other deps update (#138)
