### PR TITLE
refactor: Use workspace features for consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration_tests"
-version = "1.1.0"
+version = "1.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration_tokio_async"
-version = "0.0.1-alpha1"
+version = "1.3.0-alpha.1"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,14 @@
+[workspace.package]
+authors = ["Clément Joly <foss@131719.xyz>"]
+categories = ["database"]
+description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."
+homepage = "https://cj.rs/rusqlite_migration"
+keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
+license = "Apache-2.0"
+repository = "https://github.com/cljoly/rusqlite_migration"
+rust-version = "1.70"
+version = "1.3.0-alpha.1"
+
 [workspace]
 members = [
   "rusqlite_migration",

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
-name = "rusqlite_migration"
-version = "1.3.0-alpha.1"
-authors = ["Clément Joly <foss@131719.xyz>"]
 edition = "2021"
-license = "Apache-2.0"
-description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."
-keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
-categories = ["database"]
+name = "rusqlite_migration"
 readme = "README.md"
-homepage = "https://cj.rs/rusqlite_migration"
-repository = "https://github.com/cljoly/rusqlite_migration"
-rust-version = "1.70"
+
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 # Locally, run:
 #     RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "rusqlite_migration_tests"
-version = "1.1.0"
-authors = ["Clément Joly <foss@131719.xyz>"]
 edition = "2018"
-license = "Apache-2.0"
-description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."
-keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
-categories = ["database"]
 readme = "README.md"
-homepage = "https://cj.rs/rusqlite_migration"
-repository = "https://github.com/cljoly/rusqlite_migration"
-rust-version = "1.70"
 publish = false
+
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 tokio = { version = "1.39", features = ["macros"] }

--- a/rusqlite_migration_tokio_async/Cargo.toml
+++ b/rusqlite_migration_tokio_async/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "rusqlite_migration_tokio_async"
-version = "0.0.1-alpha1"
-authors = ["Clément Joly <foss@131719.xyz>"]
 edition = "2021"
-license = "Apache-2.0"
-description = "Simple schema migration library for rusqlite using user_version instead of an SQL table to maintain the current schema version."
-keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
-categories = ["database"]
 readme = "README.md"
-homepage = "https://cj.rs/rusqlite_migration"
-repository = "https://github.com/cljoly/rusqlite_migration/tree/master/rusqlite_migration_tokio_async"
+
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Cargo.toml have inconsistent metadata (version numbers, website,
license, repo…). Define these in the workspace and import them from the
packages.

To check that no key was changed in the main package, the output of
```
cargo read-manifest --manifest-path rusqlite_migration/Cargo.toml
```
was checked before and after this commit and it was identical.
