### PR TITLE
doc: make dep.rs badge point to latest commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ end_insert -->
 [![docs.rs](https://img.shields.io/docsrs/rusqlite_migration)][docs]
 [![Crates.io](https://img.shields.io/crates/v/rusqlite_migration)][cio]
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)][safety-dance]
-[![dependency status](https://deps.rs/crate/rusqlite_migration/1.2.0/status.svg)][deps]
+[![dependency status](https://deps.rs/crate/rusqlite_migration/latest/status.svg)][deps]
 [![Coveralls](https://img.shields.io/coverallsCoverage/github/cljoly/rusqlite_migration)][coveralls]
 
 <!-- insert


### PR DESCRIPTION
This feature seem to have been added recently. It’s nice because I
always forget to update this (for instance in the last release 1.3.0).
