### PR TITLE
test: add a test for new_iter

### DIFF
--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -553,3 +553,9 @@ fn test_missing_down_migration() {
         m.to_version(&mut conn, 2)
     );
 }
+
+#[test]
+fn test_deprecated_new_iter() {
+    let migrations = Migrations::new_iter(all_valid().into_iter());
+    assert_eq!(Ok(()), migrations.validate());
+}


### PR DESCRIPTION
Even though the function is deprecated, the code is still present and we
don’t want it to break unexpectedly.
