### PR TITLE
chore: further tweak CI trigger logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
+  # Those checks only run against code changes
+  - push
 
 name: Continuous integration
 
@@ -34,7 +30,11 @@ jobs:
     name: Cargo test
     strategy:
       matrix:
-        args: ["", "--all-features", "--features alpha-async-tokio-rusqlite", "--features from-directory"]
+        args:
+        - ""
+        - "--all-features"
+        - "--features alpha-async-tokio-rusqlite"
+        - "--features from-directory"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Turns out that "on: pull_request" triggers runs on non-code changes,
which is not useful here:

> Runs your workflow when activity on a pull request in the workflow's repository occurs. For example, if no activity types are specified, the workflow runs when a pull request is opened or reopened or when the head branch of the pull request is updated

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request

Push should be enough and should apply on forks as well: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#push
