### PR TITLE
chore(deps): update rusqlite to 0.33.0

### DIFF
--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -19,6 +19,6 @@ path = "../../rusqlite_migration"
 features = ["alpha-async-tokio-rusqlite"]
 
 [dependencies.rusqlite]
-version = "=0.32.1"
+version = "=0.33.0"
 default-features = false
 features = []

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -18,6 +18,6 @@ path = "../../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.32.1"
+version = "0.33.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -14,5 +14,5 @@ lazy_static = "1.5.0"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "0.32.1"
+version = "0.33.0"
 features = ["extra_check"] # A realistic use case

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -42,7 +42,7 @@ features = ["macros"]
 optional = true
 
 [dependencies.rusqlite]
-version = "0.32.1"
+version = "0.33.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -24,7 +24,7 @@ path = "../rusqlite_migration"
 features = ["alpha-async-tokio-rusqlite", "from-directory"]
 
 [dependencies.rusqlite]
-version = "0.32.1"
+version = "0.33.0"
 features = ["extra_check"]
 
 [dev-dependencies]


### PR DESCRIPTION
As usual, there will likely be a few blockers:
- [ ] tokio-rusqlite needs to update as well (https://github.com/programatik29/tokio-rusqlite/pull/41, https://github.com/programatik29/tokio-rusqlite/pull/42)
- [ ] Update changelog
- [x] Double check [rusqlite release notes](https://github.com/rusqlite/rusqlite/releases/tag/v0.33.0)

See https://github.com/cljoly/rusqlite_migration/pull/173 and https://github.com/cljoly/rusqlite_migration/pull/181 for the
last similar upgrade.