### PR TITLE
chore(msrv): align MSRV with rusqlite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 name: Continuous integration
 
 env:
-  MSRV: 1.77.0
+  MSRV: 1.84.0
   CARGO_TERM_COLOR: always
   # Useful for cargo insta
   CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 1.4.0
+
+### Minimum Rust Version
+
+Rust 1.84.
+
+Moving forward, we expect to keep this aligned with rusqlite itself, now that it has a [policy](https://github.com/rusqlite/rusqlite?tab=readme-ov-file#minimum-supported-rust-version-msrv) (introduced in [october 2024](https://github.com/rusqlite/rusqlite/pull/1576)).
+
 ## Version 1.3.1
 
 The only change is a fix to the deps.rs badge in the documentation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://cj.rs/rusqlite_migration"
 keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
 license = "Apache-2.0"
 repository = "https://github.com/cljoly/rusqlite_migration"
-rust-version = "1.77"
+rust-version = "1.84"
 version = "1.3.1"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ This crate is actively used in a number of projects. You can find up-to-date lis
 
 A number of contributors are also reporting issues as they arise, another indicator of active use.
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate extends rusqlite and as such is tightly integrated with it. Thus, it supports the [same MSRV][msrv] as rusqlite. At the time of writing, this means:
+
+> Latest stable Rust version at the time of release. It might compile with older versions.
+
 ## Contributing
 
 Contributions (documentation or code improvements in particular) are welcome, see [contributing][]!
@@ -181,3 +187,4 @@ Thanks to [Migadu](https://www.migadu.com/) for offering a discounted service to
 [cargo-mutants]: https://mutants.rs/installation.html
 [cheat]: https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/
 [docs]: https://docs.rs/rusqlite_migration
+[msrv]: https://github.com/rusqlite/rusqlite?tab=readme-ov-file#minimum-supported-rust-version-msrv


### PR DESCRIPTION

Starting with version [0.33](https://github.com/rusqlite/rusqlite/releases/tag/v0.33.0),
rusqlite has a policy for the minimum supported rust version (see https://github.com/rusqlite/rusqlite/pull/1576).

Align our MSRV and rusqlite’s, if rusqlite doesn’t support a particular
version (i.e. doesn’t compile), then rusqlite_migration can’t be used
either.
We could try to figure out what version of Rust still compiles with
rusqlite, beyond their official MSRV, but that’s easy to get wrong and
an additional support burden on us.

Now, for now it means that the MSRV is effectively the latest Rust
version, but that should change as new releases of Rust become stable
(i.e. if 1.85 gets out before rusqlite gets a new version, we will again
have a MSRV that’s not the latest stable Rust). Thus, it’s worth keeping
the CI code to test two different versions.
