### PR TITLE
refactor!: remove `Migrations::new_iter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ On a related note, now that we have removed the `AsyncMigrations` (see the secti
 -        .finalize::<Migrations>());
 +        .finalize());
 ```
+#### Remove `Migrations::new_iter`
+
+This function has been deprecated for a while now, remove it as a part of the major version bump. You can use the standard `FromIter` trait implementation instead.
 
 ### Minimum Rust Version
 

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -420,14 +420,6 @@ impl<'m> Migrations<'m> {
         Ok(Self { ms: migrations })
     }
 
-    /// **Deprecated**: [`Migrations`] now implements [`FromIterator`], so use [`Migrations::from_iter`] instead.
-    ///
-    /// Performs allocations transparently.
-    #[deprecated = "Use the `FromIterator` trait implementation instead. For instance, you can call Migrations::from_iter."]
-    pub fn new_iter<I: IntoIterator<Item = M<'m>>>(ms: I) -> Self {
-        Self::new(Vec::from_iter(ms))
-    }
-
     fn db_version_to_schema(&self, db_version: usize) -> SchemaVersion {
         match db_version {
             0 => SchemaVersion::NoneSet,

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -553,9 +553,3 @@ fn test_missing_down_migration() {
         m.to_version(&mut conn, 2)
     );
 }
-
-#[test]
-fn test_deprecated_new_iter() {
-    let migrations = Migrations::new_iter(all_valid().into_iter());
-    assert_eq!(Ok(()), migrations.validate());
-}


### PR DESCRIPTION
This has been deprecated for a while now, remove it along with the other
breaking changes (#39).
