### PR TITLE
chore: update copyright and license notices

### DIFF
--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::LazyLock;
 
 use anyhow::Result;

--- a/examples/from-directory/build.rs
+++ b/examples/from-directory/build.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     println!("cargo:rerun-if-changed=migrations/");
 }

--- a/examples/from-directory/src/main.rs
+++ b/examples/from-directory/src/main.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::LazyLock;
 
 use anyhow::Result;

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::LazyLock;
 
 use anyhow::Result;

--- a/rusqlite_migration/benches/criterion.rs
+++ b/rusqlite_migration/benches/criterion.rs
@@ -1,18 +1,17 @@
-/* Copyright 2022-2023 Clément Joly
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Benchmarks using criterion
 

--- a/rusqlite_migration/benches/from_directory.rs
+++ b/rusqlite_migration/benches/from_directory.rs
@@ -1,18 +1,17 @@
-/* Copyright 2023 Clément Joly
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use criterion::{criterion_group, Criterion};
 use include_dir::{include_dir, Dir};

--- a/rusqlite_migration/benches/iai.rs
+++ b/rusqlite_migration/benches/iai.rs
@@ -1,18 +1,17 @@
-/* Copyright 2023 Clément Joly
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Why criterion and iai? It’s actually recommended:
 //! https://bheisler.github.io/criterion.rs/book/iai/comparison.html

--- a/rusqlite_migration/build.rs
+++ b/rusqlite_migration/build.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Insert the readme as documentation of the crate
 
 use std::{

--- a/rusqlite_migration/src/builder.rs
+++ b/rusqlite_migration/src/builder.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{iter::FromIterator, mem::take};
 
 use include_dir::Dir;

--- a/rusqlite_migration/src/errors.rs
+++ b/rusqlite_migration/src/errors.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Custom error types
 
 use std::fmt;

--- a/rusqlite_migration/src/errors/tests.rs
+++ b/rusqlite_migration/src/errors/tests.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::num::NonZeroUsize;
 
 use super::*;

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -1,18 +1,17 @@
-/* Copyright 2020 Clément Joly
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // The doc is extracted from the README.md file at build time

--- a/rusqlite_migration/src/loader.rs
+++ b/rusqlite_migration/src/loader.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{convert::TryFrom, num::NonZeroUsize};
 
 use crate::{Error, Result, M};

--- a/rusqlite_migration/src/tests/builder.rs
+++ b/rusqlite_migration/src/tests/builder.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{iter::FromIterator, num::NonZeroUsize};
 
 use rusqlite::Connection;

--- a/rusqlite_migration/src/tests/helpers.rs
+++ b/rusqlite_migration/src/tests/helpers.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::M;
 
 pub fn m_valid0() -> M<'static> {

--- a/rusqlite_migration/src/tests/mod.rs
+++ b/rusqlite_migration/src/tests/mod.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // For feature "from-directory"
 mod builder;
 

--- a/rusqlite_migration/src/tests/synch.rs
+++ b/rusqlite_migration/src/tests/synch.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{iter::FromIterator, num::NonZeroUsize};
 
 use rusqlite::{Connection, OpenFlags, Transaction};

--- a/rusqlite_migration_tests/tests/from_directory_test.rs
+++ b/rusqlite_migration_tests/tests/from_directory_test.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::num::NonZeroUsize;
 
 use include_dir::{include_dir, Dir};

--- a/rusqlite_migration_tests/tests/integration_test.rs
+++ b/rusqlite_migration_tests/tests/integration_test.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::num::NonZeroUsize;
 
 use rusqlite::{params, Connection};

--- a/rusqlite_migration_tests/tests/lib.rs
+++ b/rusqlite_migration_tests/tests/lib.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod from_directory_test;
 mod integration_test;
 mod migrations_builder_from_iterator_test;

--- a/rusqlite_migration_tests/tests/migrations_builder_from_iterator_test.rs
+++ b/rusqlite_migration_tests/tests/migrations_builder_from_iterator_test.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{iter::FromIterator, num::NonZeroUsize};
 
 use rusqlite::{params, Connection, Transaction};

--- a/rusqlite_migration_tests/tests/migrations_builder_test.rs
+++ b/rusqlite_migration_tests/tests/migrations_builder_test.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::num::NonZeroUsize;
 
 use include_dir::{include_dir, Dir};

--- a/rusqlite_migration_tests/tests/multiline_test.rs
+++ b/rusqlite_migration_tests/tests/multiline_test.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::num::NonZeroUsize;
 
 use rusqlite::{params, Connection};

--- a/rusqlite_migration_tests/tests/up_and_down.rs
+++ b/rusqlite_migration_tests/tests/up_and_down.rs
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Clément Joly and contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::num::NonZeroUsize;
 
 use rusqlite::{params, Connection};


### PR DESCRIPTION
This is in line with [the guidelines][notices]. In particular:
- I did not alter anyone else’s copyright notices, only my own.
- Fine grained copyright ownership is tracked in Git.

We also specify the license with an SPDX License Identifier (along with
the license notices). This is NOT a license change.

[notices]: https://cj.rs/open-source/docs/contribute/#copyright-notices
