### PR TITLE
refactor!: make `Migrations` use `Cow<[M]>` instead of `Vec<M>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let migrations = Migrations::new(vec![
     M::up("CREATE TABLE friend(name TEXT NOT NULL);"),
     // In the future, add more migrations here:
     //M::up("ALTER TABLE friend ADD COLUMN email TEXT;"),
-]);
+].into());
 
 let mut conn = Connection::open_in_memory().unwrap();
 
@@ -108,7 +108,7 @@ The migrations object is also suitable for serialisation with [insta][], using t
 fn migrations_insta_snapshot() {
     let migrations = Migrations::new(vec![
         // ...
-    ]);
+    ].into());
     insta::assert_debug_snapshot!(migrations);
 }
 ```

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::LazyLock;
+use std::borrow::Cow;
 
 use anyhow::Result;
 use rusqlite::params;
@@ -40,24 +40,23 @@ mod tests {
 }
 
 // Define migrations. These are applied atomically.
-static MIGRATIONS: LazyLock<Migrations> = LazyLock::new(|| {
-    Migrations::new(vec![
-        M::up(include_str!("../../friend_car.sql")),
-        // PRAGMA are better applied outside of migrations, see below for details.
-        M::up(
-            r#"
-                  ALTER TABLE friend ADD COLUMN birthday TEXT;
-                  ALTER TABLE friend ADD COLUMN comment TEXT;
-                  "#,
-        ),
-        // This migration can be reverted
-        M::up("CREATE TABLE animal(name TEXT);").down("DROP TABLE animal;"),
-        // In the future, if the need to change the schema arises, put
-        // migrations here, like so:
-        // M::up("CREATE INDEX UX_friend_email ON friend(email);"),
-        // M::up("CREATE INDEX UX_friend_name ON friend(name);"),
-    ])
-});
+const MIGRATION_ARRAY: &[M] = &[
+    M::up(include_str!("../../friend_car.sql")),
+    // PRAGMA are better applied outside of migrations, see below for details.
+    M::up(
+        r#"
+        ALTER TABLE friend ADD COLUMN birthday TEXT;
+        ALTER TABLE friend ADD COLUMN comment TEXT;
+        "#,
+    ),
+    // This migration can be reverted
+    M::up("CREATE TABLE animal(name TEXT);").down("DROP TABLE animal;"),
+    // In the future, if the need to change the schema arises, put
+    // migrations here, like so:
+    // M::up("CREATE INDEX UX_friend_email ON friend(email);"),
+    // M::up("CREATE INDEX UX_friend_name ON friend(name);"),
+];
+const MIGRATIONS: Migrations = Migrations::new(Cow::Borrowed(MIGRATION_ARRAY));
 
 pub async fn init_db() -> Result<Connection> {
     let async_conn = Connection::open("./my_db.db3").await?;

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::LazyLock;
+use std::borrow::Cow;
 
 use anyhow::Result;
 use rusqlite::{params, Connection};
@@ -31,24 +31,23 @@ mod tests {
 }
 
 // Define migrations. These are applied atomically.
-static MIGRATIONS: LazyLock<Migrations<'static>> = LazyLock::new(|| {
-    Migrations::new(vec![
-        M::up(include_str!("../../friend_car.sql")),
-        // PRAGMA are better applied outside of migrations, see below for details.
-        M::up(
-            r#"
-                ALTER TABLE friend ADD COLUMN birthday TEXT;
-                ALTER TABLE friend ADD COLUMN comment TEXT;
-                "#,
-        ),
-        // This migration can be reverted
-        M::up("CREATE TABLE animal(name TEXT);").down("DROP TABLE animal;"),
-        // In the future, if the need to change the schema arises, put
-        // migrations here, like so:
-        // M::up("CREATE INDEX UX_friend_email ON friend(email);"),
-        // M::up("CREATE INDEX UX_friend_name ON friend(name);"),
-    ])
-});
+const MIGRATION_ARRAY: &[M] = &[
+    M::up(include_str!("../../friend_car.sql")),
+    // PRAGMA are better applied outside of migrations, see below for details.
+    M::up(
+        r#"
+        ALTER TABLE friend ADD COLUMN birthday TEXT;
+        ALTER TABLE friend ADD COLUMN comment TEXT;
+        "#,
+    ),
+    // This migration can be reverted
+    M::up("CREATE TABLE animal(name TEXT);").down("DROP TABLE animal;"),
+    // In the future, if the need to change the schema arises, put
+    // migrations here, like so:
+    // M::up("CREATE INDEX UX_friend_email ON friend(email);"),
+    // M::up("CREATE INDEX UX_friend_name ON friend(name);"),
+];
+const MIGRATIONS: Migrations = Migrations::new(Cow::Borrowed(MIGRATION_ARRAY));
 
 pub fn init_db() -> Result<Connection> {
     let mut conn = Connection::open("./my_db.db3")?;

--- a/rusqlite_migration/src/tests/helpers.rs
+++ b/rusqlite_migration/src/tests/helpers.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use crate::M;
 
 use rusqlite::Connection;
@@ -71,7 +73,7 @@ pub fn m_invalid_down_fk() -> M<'static> {
 }
 
 // All valid Ms in the right order
-pub fn all_valid() -> Vec<M<'static>> {
+pub fn all_valid() -> Cow<'static, [M<'static>]> {
     vec![
         m_valid0(),
         m_valid10(),
@@ -80,6 +82,7 @@ pub fn all_valid() -> Vec<M<'static>> {
         m_valid21(),
         m_valid_fk(),
     ]
+    .into()
 }
 
 pub fn m_invalid0() -> M<'static> {

--- a/rusqlite_migration_tests/tests/integration_test.rs
+++ b/rusqlite_migration_tests/tests/integration_test.rs
@@ -29,7 +29,7 @@ fn main_test() {
     ];
 
     {
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(
@@ -49,7 +49,7 @@ fn main_test() {
     ms.push(M::up("ALTER TABLE friend RENAME COLUMN birthday TO birth;"));
 
     {
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(
@@ -68,7 +68,7 @@ fn main_test() {
     ms.push(M::up("DROP INDEX UX_friend_email;"));
 
     {
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(

--- a/rusqlite_migration_tests/tests/multiline_test.rs
+++ b/rusqlite_migration_tests/tests/multiline_test.rs
@@ -33,7 +33,7 @@ fn main_test() {
     {
         let mut conn = Connection::open(&db_file).unwrap();
 
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
         migrations.to_latest(&mut conn).unwrap();
 
         conn.pragma_update_and_check(None, "journal_mode", "WAL", |r| {
@@ -93,7 +93,7 @@ fn main_test() {
     {
         let mut conn = Connection::open(&db_file).unwrap();
 
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
         migrations.to_latest(&mut conn).unwrap();
 
         assert_eq!(

--- a/rusqlite_migration_tests/tests/up_and_down.rs
+++ b/rusqlite_migration_tests/tests/up_and_down.rs
@@ -40,7 +40,7 @@ fn main_test() {
     {
         let mut conn = Connection::open_in_memory().unwrap();
 
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
 
         assert_eq!(
             Ok(SchemaVersion::NoneSet),
@@ -75,7 +75,7 @@ fn main_test() {
     {
         let mut conn = Connection::open_in_memory().unwrap();
 
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
 
         assert_eq!(
             Ok(SchemaVersion::NoneSet),
@@ -147,7 +147,7 @@ fn test_errors() {
     {
         let mut conn = Connection::open_in_memory().unwrap();
 
-        let migrations = Migrations::new(ms.clone());
+        let migrations = Migrations::new(ms.clone().into());
 
         migrations.to_latest(&mut conn).unwrap();
         // Successful even on the second run (the most common case once migrations have been


### PR DESCRIPTION
This has a couple of advantages:

* It avoids being forced to allocate if the set of migrations is known at compile time.
* It removes the need for `LazyLock<Migrations>` in a `static`, as it allows constructing `Migrations` from a `const` array (`&[M]`) as a constant (see `examples/simple/src/main.rs`).

Downsides:

* It requires adding `.into()` when passing in a Vec, making it a breaking change (the Rust compiler suggests the correct fix, which is helpful). (It would be cool to have `Migrations::new` accept a `impl Into<Cow<'m, [M<'m>]>>`, but unfortunately `Into` isn't `const`, so it isn't possible, and removing `const` from `Migrations::new` would negate one of the benefits of doing this.)

(I completely understand if this isn't accepted.)