### PR TITLE
refactor: Keep migrations in `Cow` instead of `Vec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ end_insert -->
 Release notes for the [rusqlite_migration library](https://cj.rs/rusqlite_migration).
 end_insert -->
 
+## Version 2.0.0 Beta 1
+
+### Features
+
+- Add the new `Migrations::from_slice` constructor, which is `const` and takes a slice, so that it can be constructed in global constant, without using `LazyLock` or similar.
 
 ## Version 2.0.0 Alpha 1
 

--- a/README.md
+++ b/README.md
@@ -62,29 +62,32 @@ use rusqlite::{params, Connection};
 use rusqlite_migration::{Migrations, M};
 
 // 1️⃣ Define migrations
-let migrations = Migrations::new(vec![
+const MIGRATION_SLICE: &[M<'_>] = &[
     M::up("CREATE TABLE friend(name TEXT NOT NULL);"),
     // In the future, add more migrations here:
     //M::up("ALTER TABLE friend ADD COLUMN email TEXT;"),
-]);
+];
+const MIGRATIONS: Migrations<'_> = Migrations::from_slice(MIGRATION_SLICE);
 
-let mut conn = Connection::open_in_memory().unwrap();
+fn main() {
+    let mut conn = Connection::open_in_memory().unwrap();
 
-// Apply some PRAGMA, often better to do it outside of migrations
-conn.pragma_update_and_check(None, "journal_mode", &"WAL", |_| Ok(())).unwrap();
+    // Apply some PRAGMA, often better to do it outside of migrations
+    conn.pragma_update_and_check(None, "journal_mode", &"WAL", |_| Ok(()))
+        .unwrap();
 
-// 2️⃣ Update the database schema, atomically
-migrations.to_latest(&mut conn).unwrap();
+    // 2️⃣ Update the database schema, atomically
+    MIGRATIONS.to_latest(&mut conn).unwrap();
 
-// 3️⃣ Use the database 🥳
-conn.execute("INSERT INTO friend (name) VALUES (?1)", params!["John"])
-    .unwrap();
+    // 3️⃣ Use the database 🥳
+    conn.execute("INSERT INTO friend (name) VALUES (?1)", params!["John"])
+        .unwrap();
+}
 ```
 
 Please see the [examples](https://github.com/cljoly/rusqlite_migrate/tree/master/examples) folder for more, in particular:
 - migrations with multiple SQL statements (using for instance `r#"…"` or `include_str!(…)`)
 - migrations defined [from a directory][from_dir] with SQL files
-- use of [`LazyLock`][lazy_lock] (or [lazy_static][] with older versions of Rust)
 - migrations to [previous versions (downward migrations)][generic_example]
 - migrations [when using `async`][quick_start_async]
 
@@ -178,7 +181,6 @@ Thanks to [Migadu](https://www.migadu.com/) for offering a discounted service to
 [safety-dance]: https://github.com/rust-secure-code/safety-dance/
 [cio]: https://crates.io/crates/rusqlite_migration
 [cio_reverse]: https://crates.io/crates/rusqlite_migration/reverse_dependencies
-[lazy_lock]: https://doc.rust-lang.org/std/sync/struct.LazyLock.html
 [lrs_reverse]: https://lib.rs/crates/rusqlite_migration/rev
 [gh_reverse]: https://github.com/cljoly/rusqlite_migration/network/dependents?dependent_type=REPOSITORY
 [contributing]: https://cj.rs/docs/contribute/
@@ -194,6 +196,5 @@ Thanks to [Migadu](https://www.migadu.com/) for offering a discounted service to
 [docs]: https://docs.rs/rusqlite_migration
 [msrv]: https://github.com/rusqlite/rusqlite?tab=readme-ov-file#minimum-supported-rust-version-msrv
 [from_dir]: https://github.com/cljoly/rusqlite_migration/tree/master/examples/from-directory
-[lazy_static]: https://github.com/cljoly/rusqlite_migration/blob/f3d19847065b890efe73c27393b2980d1571f871/examples/simple/src/main.rs#L18
 [generic_example]: https://github.com/cljoly/rusqlite_migration/blob/master/examples/simple/src/main.rs
 [quick_start_async]: https://github.com/cljoly/rusqlite_migration/blob/master/examples/async/src/main.rs

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::LazyLock;
-
 use anyhow::Result;
 use rusqlite::{params, Connection};
 use rusqlite_migration::{Migrations, M};
@@ -31,24 +29,23 @@ mod tests {
 }
 
 // Define migrations. These are applied atomically.
-static MIGRATIONS: LazyLock<Migrations<'static>> = LazyLock::new(|| {
-    Migrations::new(vec![
-        M::up(include_str!("../../friend_car.sql")),
-        // PRAGMA are better applied outside of migrations, see below for details.
-        M::up(
-            r#"
-                ALTER TABLE friend ADD COLUMN birthday TEXT;
-                ALTER TABLE friend ADD COLUMN comment TEXT;
-                "#,
-        ),
-        // This migration can be reverted
-        M::up("CREATE TABLE animal(name TEXT);").down("DROP TABLE animal;"),
-        // In the future, if the need to change the schema arises, put
-        // migrations here, like so:
-        // M::up("CREATE INDEX UX_friend_email ON friend(email);"),
-        // M::up("CREATE INDEX UX_friend_name ON friend(name);"),
-    ])
-});
+const MIGRATION_ARRAY: &[M] = &[
+    M::up(include_str!("../../friend_car.sql")),
+    // PRAGMA are better applied outside of migrations, see below for details.
+    M::up(
+        r#"
+        ALTER TABLE friend ADD COLUMN birthday TEXT;
+        ALTER TABLE friend ADD COLUMN comment TEXT;
+        "#,
+    ),
+    // This migration can be reverted
+    M::up("CREATE TABLE animal(name TEXT);").down("DROP TABLE animal;"),
+    // In the future, if the need to change the schema arises, put
+    // migrations here, like so:
+    // M::up("CREATE INDEX UX_friend_email ON friend(email);"),
+    // M::up("CREATE INDEX UX_friend_name ON friend(name);"),
+];
+const MIGRATIONS: Migrations = Migrations::from_slice(MIGRATION_ARRAY);
 
 pub fn init_db() -> Result<Connection> {
     let mut conn = Connection::open("./my_db.db3")?;

--- a/rusqlite_migration/src/tests/core.rs
+++ b/rusqlite_migration/src/tests/core.rs
@@ -492,3 +492,11 @@ fn test_missing_down_migration() {
         m.to_version(&mut conn, 2)
     );
 }
+
+// We can build from a Cow type easily enough
+#[test]
+fn test_build_from_cow() {
+    use std::borrow::Cow;
+
+    let _ = Migrations::from_slice(&Cow::from(vec![m_valid0()]));
+}


### PR DESCRIPTION
This builds on https://github.com/cljoly/rusqlite_migration/pull/251 and
proposes another path. Like #251, it provides a method to store the
migrations in a `const` context, but:
* it does so without breaking changes, at least compared to the latest
  release: `new` is not const anymore, but that change was not released
  in a stable version.
* exposes only concrete types like `Vec` and slices to build the
  migrations, instead of the discussed `impl Into<Cow<'m, [M<'m>]>>`.
  This should make the compiler report clearer errors, improving
  usability.
* we can still easily built from a `Cow` type, by borrowing it.

Drawbacks
---------

The main drawback I can think of is this: the most intuitive function to
call (`new`) takes a `Vec`, while it would be better to just use a slice
(which `from_slice` takes). But that cost should be minimal and
preserves backward compatibility.

Co-authored-by: Joaquim Monteiro <joaquim.monteiro@protonmail.com>
