### PR TITLE
Version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ end_insert -->
 Release notes for the [rusqlite_migration library](https://cj.rs/rusqlite_migration).
 end_insert -->
 
+## Version 2.1.0
+
+### Dependencies
+
+Rusqlite was updated from 0.34.0 to 0.34.0.
+Please see [the release notes for 0.35.0](https://github.com/rusqlite/rusqlite/releases/tag/v0.35.0).
+
 ## Version 2.0.0
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,9 +549,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
+checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -832,9 +832,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rusqlite"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
+checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration_tests"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1045,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite-new"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fefb7831617a21ef3c6291a9307acc3abd37be71869335aafa6aa61cff1a91"
+checksum = "a040ff4d5e6323faf4adc2923fd9c1cea8e4ba3abf7063b8892bd53b5bd3587e"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
 license = "Apache-2.0"
 repository = "https://github.com/cljoly/rusqlite_migration"
 rust-version = "1.84"
-version = "2.0.1"
+version = "2.1.0"
 
 [workspace]
 members = [

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -10,13 +10,13 @@ simple-logging = "2.0.2"
 env_logger = "0.11"
 anyhow = "1"
 mktemp = "0.5"
-tokio-rusqlite-new = "=0.8.0"
+tokio-rusqlite-new = "=0.9.0"
 tokio = { version = "1.44.2", features = ["full"] }
 
 [dependencies.rusqlite_migration]
 path = "../../rusqlite_migration"
 
 [dependencies.rusqlite]
-version = "=0.34.0"
+version = "0.35.0"
 default-features = false
 features = []

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -17,6 +17,6 @@ path = "../../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.34.0"
+version = "0.35.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -13,5 +13,5 @@ anyhow = "1"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "0.34.0"
+version = "0.35.0"
 features = ["extra_check"] # A realistic use case

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -34,7 +34,7 @@ include_dir = { version = "0.7.4", optional = true }
 log = "0.4"
 
 [dependencies.rusqlite]
-version = "0.34.0"
+version = "0.35.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -22,7 +22,7 @@ path = "../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.34.0"
+version = "0.35.0"
 features = ["extra_check"]
 
 [dev-dependencies]


### PR DESCRIPTION

For the update of `tokio-rusqlite-new` in the async example (which users
may import based on the guidance in this example), I have once again
looked at the diff and I did not spot anything:

```sh
diff -U 3 -x Cargo.lock ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/ ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/
```
output:
```diff
diff -U 3 -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/.cargo_vcs_info.json /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/.cargo_vcs_info.json
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/.cargo_vcs_info.json	1970-01-01 00:00:01.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/.cargo_vcs_info.json	1970-01-01 00:00:01.000000000 +0000
@@ -1,6 +1,6 @@
 {
   "git": {
-    "sha1": "fc2779b3e3c505efbf224537e68313eaa816ef20"
+    "sha1": "bf9def984c91f8375be376e946f4ee007e368d84"
   },
   "path_in_vcs": ""
 }
\ No newline at end of file
diff -U 3 -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/CHANGELOG.md /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/CHANGELOG.md
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/CHANGELOG.md	2006-07-24 01:21:28.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/CHANGELOG.md	2006-07-24 01:21:28.000000000 +0000
@@ -8,6 +8,10 @@

 Nothing.

+# 0.9.0 (21 Apr 2025)
+
+- **updated:** To latest [rusqlite] version (`0.35`).
+
 # 0.8.0 (6 Mar 2025)

 - **updated:** To latest [rusqlite] version (`0.34`).
diff -U 3 -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/Cargo.toml /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/Cargo.toml	1970-01-01 00:00:01.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml	1970-01-01 00:00:01.000000000 +0000
@@ -12,7 +12,7 @@
 [package]
 edition = "2021"
 name = "tokio-rusqlite-new"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "xuxiaocheng <2762267080@qq.com>",
     "Programatik <programatik29@gmail.com>",
@@ -62,18 +62,18 @@
 version = "~0.5"

 [dependencies.rusqlite]
-version = "~0.34"
+version = "~0.35"

 [dependencies.tokio]
-version = "^1.43"
+version = "^1.44"
 features = ["sync"]

 [dev-dependencies.rusqlite]
-version = "~0.34"
+version = "~0.35"
 features = ["bundled"]

 [dev-dependencies.tokio]
-version = "^1.43"
+version = "^1.44"
 features = [
     "rt-multi-thread",
     "macros",
diff -U 3 -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/Cargo.toml.orig /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml.orig
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/Cargo.toml.orig	2006-07-24 01:21:28.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml.orig	2006-07-24 01:21:28.000000000 +0000
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rusqlite-new"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["xuxiaocheng <2762267080@qq.com>", "Programatik <programatik29@gmail.com>", "Adi Salimgereev <adisalimgereev@gmail.com>"]
 edition = "2021"
 description = "Asynchronous handle for rusqlite library."
@@ -15,12 +15,12 @@

 [dependencies]
 crossbeam-channel = "~0.5"
-rusqlite = "~0.34"
-tokio = { version = "^1.43", features = ["sync"] }
+rusqlite = "~0.35"
+tokio = { version = "^1.44", features = ["sync"] }

 [dev-dependencies]
-rusqlite = { version = "~0.34", features = ["bundled"] }
-tokio = { version = "^1.43", features = ["rt-multi-thread", "macros"] }
+rusqlite = { version = "~0.35", features = ["bundled"] }
+tokio = { version = "^1.44", features = ["rt-multi-thread", "macros"] }

 [[test]]
 name = "tests"
Common subdirectories: /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/examples and /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/examples
Common subdirectories: /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/src and /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/src
Common subdirectories: /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.8.0/tests and /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/tests
```

