### PR TITLE
chore: add docs.rs link to Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ homepage = "https://cj.rs/rusqlite_migration"
 keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
 license = "Apache-2.0"
 repository = "https://github.com/cljoly/rusqlite_migration"
+documentation = "https://docs.rs/rusqlite_migration/"
 rust-version = "1.84"
 version = "2.1.0"
 


### PR DESCRIPTION
Crates.io uses that to display a “Documentation” link in search results
(and presumably other places).
