### PR TITLE
test: test error equality more thoroughly

### DIFF
--- a/rusqlite_migration/src/errors/tests.rs
+++ b/rusqlite_migration/src/errors/tests.rs
@@ -334,3 +334,41 @@ fn error_test_source() {
     let err = Error::FileLoad(String::new());
     assert!(std::error::Error::source(&err).is_none());
 }
+
+#[test]
+// Test cases where enum comparison is not enouh for error equality
+fn test_migration_enum_eq_not_enough() {
+    let mde1 = MigrationDefinitionError::DownNotDefined { migration_index: 3 };
+    let mde2 = MigrationDefinitionError::DownNotDefined { migration_index: 5 };
+    assert_ne!(
+        Error::MigrationDefinition(mde1),
+        Error::MigrationDefinition(mde2),
+    );
+
+    let fce = ForeignKeyCheckError {
+        table: String::from("t1"),
+        rowid: 23,
+        parent: String::from("t2"),
+        fkid: 42,
+    };
+    assert_eq!(
+        Error::ForeignKeyCheck(vec![fce.clone()]),
+        Error::ForeignKeyCheck(vec![fce.clone()])
+    );
+    assert_ne!(
+        Error::ForeignKeyCheck(vec![fce.clone()]),
+        Error::ForeignKeyCheck(vec![ForeignKeyCheckError {
+            fkid: 32,
+            ..fce.clone()
+        }])
+    );
+    assert_ne!(
+        Error::ForeignKeyCheck(vec![fce.clone()]),
+        Error::ForeignKeyCheck(vec![])
+    );
+
+    assert_ne!(
+        Error::Hook(String::from("auie")),
+        Error::Hook(String::default())
+    )
+}


### PR DESCRIPTION

Newer versions of `cargo mutants` (25.0.1) find that removing some of
the match arms doesn’t make the tests fail. Effectively, the tests don’t
check if we are doing anything more than the fallback enum comparison.

Mutants found:
```
MISSED   rusqlite_migration/src/errors.rs:63:13: delete match arm in 0.7s build + 0.7s test
MISSED   rusqlite_migration/src/errors.rs:65:13: delete match arm in 0.6s build + 0.7s test
```

