### PR TITLE
test: refactor tests, adding downward migrations

### DIFF
--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -103,15 +103,17 @@ pub struct M<'u> {
 
 impl PartialEq for M<'_> {
     fn eq(&self, other: &Self) -> bool {
+        use std::ptr;
+
         let equal_up_hooks = match (self.up_hook.as_ref(), other.up_hook.as_ref()) {
             (None, None) => true,
-            (Some(a), Some(b)) => addr_of!(*a) as usize == addr_of!(*b) as usize,
+            (Some(a), Some(b)) => ptr::eq(addr_of!(*a), addr_of!(*b)),
             _ => false,
         };
 
         let equal_down_hooks = match (self.down_hook.as_ref(), other.down_hook.as_ref()) {
             (None, None) => true,
-            (Some(a), Some(b)) => addr_of!(*a) as usize == addr_of!(*b) as usize,
+            (Some(a), Some(b)) => ptr::eq(addr_of!(*a), addr_of!(*b)),
             _ => false,
         };
 

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__len_builder.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__len_builder.snap
@@ -1,6 +1,7 @@
 ---
 source: rusqlite_migration/src/tests/builder.rs
 expression: migrations
+snapshot_kind: text
 ---
 Migrations {
     ms: [

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__valid_index.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__builder__valid_index.snap
@@ -1,6 +1,7 @@
 ---
 source: rusqlite_migration/src/tests/builder.rs
-expression: "MigrationsBuilder::from_iter(ms).edit(1,\n            move |m|\n                m.down(\"DROP TABLE t1;\")).edit(2,\n        move |m| m.down(\"DROP TABLE t2;\")).finalize::<Migrations>()"
+expression: "MigrationsBuilder::from_iter(ms).edit(1, move |m|\nm.down(\"DROP TABLE t1;\")).edit(2, move |m|\nm.down(\"DROP TABLE t2;\")).finalize()"
+snapshot_kind: text
 ---
 Migrations {
     ms: [

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__all_valid_down_test.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__all_valid_down_test.snap
@@ -1,13 +1,16 @@
 ---
-source: rusqlite_migration/src/tests/synch.rs
+source: rusqlite_migration/src/tests/core.rs
 expression: migrations
+snapshot_kind: text
 ---
 Migrations {
     ms: [
         M {
             up: "CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);",
             up_hook: None,
-            down: None,
+            down: Some(
+                "DROP TABLE m1; DROP TABLE m2;",
+            ),
             down_hook: None,
             foreign_key_check: false,
             comment: None,
@@ -15,7 +18,9 @@ Migrations {
         M {
             up: "CREATE TABLE t1(a, b);",
             up_hook: None,
-            down: None,
+            down: Some(
+                "DROP TABLE t1;",
+            ),
             down_hook: None,
             foreign_key_check: false,
             comment: None,
@@ -23,7 +28,9 @@ Migrations {
         M {
             up: "ALTER TABLE t1 RENAME COLUMN b TO c;",
             up_hook: None,
-            down: None,
+            down: Some(
+                "ALTER TABLE t1 RENAME COLUMN c TO b;",
+            ),
             down_hook: None,
             foreign_key_check: false,
             comment: None,
@@ -31,7 +38,9 @@ Migrations {
         M {
             up: "CREATE TABLE t2(b);",
             up_hook: None,
-            down: None,
+            down: Some(
+                "DROP TABLE t2;",
+            ),
             down_hook: None,
             foreign_key_check: false,
             comment: None,
@@ -39,7 +48,9 @@ Migrations {
         M {
             up: "ALTER TABLE t2 ADD COLUMN a;",
             up_hook: None,
-            down: None,
+            down: Some(
+                "ALTER TABLE t2 DROP COLUMN a;",
+            ),
             down_hook: None,
             foreign_key_check: false,
             comment: None,
@@ -47,7 +58,9 @@ Migrations {
         M {
             up: "\n        CREATE TABLE fk1(a PRIMARY KEY);\n        CREATE TABLE fk2(\n            a,\n            FOREIGN KEY(a) REFERENCES fk1(a)\n        );\n        INSERT INTO fk1 (a) VALUES ('foo');\n        INSERT INTO fk2 (a) VALUES ('foo');\n    ",
             up_hook: None,
-            down: None,
+            down: Some(
+                "DELETE FROM fk2; DELETE FROM fk1; DROP TABLE fk2; DROP TABLE fk1;",
+            ),
             down_hook: None,
             foreign_key_check: true,
             comment: None,

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__all_valid_up_test.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__all_valid_up_test.snap
@@ -1,0 +1,57 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: migrations
+snapshot_kind: text
+---
+Migrations {
+    ms: [
+        M {
+            up: "CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+        M {
+            up: "CREATE TABLE t1(a, b);",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+        M {
+            up: "ALTER TABLE t1 RENAME COLUMN b TO c;",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+        M {
+            up: "CREATE TABLE t2(b);",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+        M {
+            up: "ALTER TABLE t2 ADD COLUMN a;",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: false,
+            comment: None,
+        },
+        M {
+            up: "\n        CREATE TABLE fk1(a PRIMARY KEY);\n        CREATE TABLE fk2(\n            a,\n            FOREIGN KEY(a) REFERENCES fk1(a)\n        );\n        INSERT INTO fk1 (a) VALUES ('foo');\n        INSERT INTO fk2 (a) VALUES ('foo');\n    ",
+            up_hook: None,
+            down: None,
+            down_hook: None,
+            foreign_key_check: true,
+            comment: None,
+        },
+    ],
+}

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__invalid_fk_check_test.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__invalid_fk_check_test.snap
@@ -1,6 +1,7 @@
 ---
-source: rusqlite_migration/src/tests/synch.rs
+source: rusqlite_migration/src/tests/core.rs
 expression: migrations.validate()
+snapshot_kind: text
 ---
 Err(
     ForeignKeyCheck(

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__migration_hook_debug.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__migration_hook_debug.snap
@@ -1,6 +1,7 @@
 ---
-source: rusqlite_migration/src/tests/synch.rs
+source: rusqlite_migration/src/tests/core.rs
 expression: m
+snapshot_kind: text
 ---
 M {
     up: "",

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__read_only_db_all_valid.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__read_only_db_all_valid.snap
@@ -1,6 +1,7 @@
 ---
-source: rusqlite_migration/src/tests/synch.rs
+source: rusqlite_migration/src/tests/core.rs
 expression: e
+snapshot_kind: text
 ---
 Err(
     RusqliteError {

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__user_version_error.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__user_version_error.snap
@@ -1,6 +1,7 @@
 ---
-source: rusqlite_migration/src/tests/synch.rs
+source: rusqlite_migration/src/tests/core.rs
 expression: e
+snapshot_kind: text
 ---
 Err(
     RusqliteError {


### PR DESCRIPTION
This will also be useful when we introduce optional validation of
downward migrations (#113)