### PR TITLE
feat: implement Display for M

### DIFF
--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -18,6 +18,7 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/readme_for_rustdoc.md"))]
 
 use std::borrow::Cow;
+use std::fmt::Display;
 
 use log::{debug, info, trace, warn};
 use rusqlite::{Connection, Transaction};
@@ -99,6 +100,38 @@ pub struct M<'u> {
     down_hook: Option<Box<dyn MigrationHook>>,
     foreign_key_check: bool,
     comment: Option<&'u str>,
+}
+
+impl Display for M<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let M {
+            up,
+            up_hook,
+            down,
+            down_hook,
+            foreign_key_check,
+            comment,
+        } = self;
+        let nl = if f.alternate() { "\n" } else { "" };
+        let ind = if f.alternate() { "\n    " } else { "" };
+        write!(f, r#"M({ind}up: "{up}""#)?;
+        if up_hook.is_some() {
+            write!(f, ", {ind}up hook")?;
+        }
+        if let Some(down) = down {
+            write!(f, r#", {ind}down: "{down}""#)?;
+        }
+        if down_hook.is_some() {
+            write!(f, ", {ind}down hook")?;
+        }
+        if *foreign_key_check {
+            write!(f, ", {ind}foreign key check")?;
+        }
+        if let Some(comment) = comment {
+            write!(f, r#", {ind}comment: "{comment}""#)?;
+        }
+        write!(f, "{nl})")
+    }
 }
 
 impl PartialEq for M<'_> {

--- a/rusqlite_migration/src/tests/core.rs
+++ b/rusqlite_migration/src/tests/core.rs
@@ -17,7 +17,7 @@ use std::{iter::FromIterator, num::NonZeroUsize};
 
 use rusqlite::{Connection, OpenFlags, Transaction};
 
-use crate::tests::helpers::all_valid_down;
+use crate::tests::helpers::{all_valid_down, m_valid0_down, m_valid_fk_down};
 use crate::{
     tests::helpers::{
         all_valid_up, m_invalid_fk, m_invalid_fk_down, m_valid0_up, m_valid10_up, m_valid11_up,
@@ -572,4 +572,29 @@ fn test_pending_migrations_errors() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     Ok(())
+}
+
+#[test]
+fn test_display() {
+    insta::assert_snapshot!("up_only", m_valid0_up());
+    insta::assert_snapshot!("up_only_alt", format!("{:#}", m_valid0_up()));
+
+    insta::assert_snapshot!("up_down", m_valid0_down());
+    insta::assert_snapshot!("up_down_alt", format!("{:#}", m_valid0_down()));
+
+    insta::assert_snapshot!("up_down_fk", m_valid_fk_down());
+    insta::assert_snapshot!("up_down_fk_alt", format!("{:#}", m_valid_fk_down()));
+
+    let everything = M {
+        up: "UP",
+        up_hook: Some(Box::new(|_: &Transaction| Ok(()))),
+        down: Some("DOWN"),
+        down_hook: Some(Box::new(|_: &Transaction| Ok(()))),
+        foreign_key_check: true,
+        comment: Some("Comment, likely a filename in practice!"),
+    };
+    insta::assert_snapshot!("everything", everything);
+    insta::assert_debug_snapshot!("everything_debug", everything);
+    insta::assert_compact_debug_snapshot!("everything_compact_debug", everything);
+    insta::assert_snapshot!("everything_alt", format!("{everything:#}"));
 }

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything.snap
@@ -1,0 +1,6 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: everything
+snapshot_kind: text
+---
+M(up: "UP", up hook, down: "DOWN", down hook, foreign key check, comment: "Comment, likely a filename in practice!")

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything_alt.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything_alt.snap
@@ -1,0 +1,13 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: "format!(\"{everything:#}\")"
+snapshot_kind: text
+---
+M(
+    up: "UP", 
+    up hook, 
+    down: "DOWN", 
+    down hook, 
+    foreign key check, 
+    comment: "Comment, likely a filename in practice!"
+)

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything_compact_debug.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything_compact_debug.snap
@@ -1,0 +1,6 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: everything
+snapshot_kind: text
+---
+M { up: "UP", up_hook: Some(MigrationHook(<closure>)), down: Some("DOWN"), down_hook: Some(MigrationHook(<closure>)), foreign_key_check: true, comment: Some("Comment, likely a filename in practice!") }

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything_debug.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__everything_debug.snap
@@ -1,0 +1,21 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: everything
+snapshot_kind: text
+---
+M {
+    up: "UP",
+    up_hook: Some(
+        MigrationHook(<closure>),
+    ),
+    down: Some(
+        "DOWN",
+    ),
+    down_hook: Some(
+        MigrationHook(<closure>),
+    ),
+    foreign_key_check: true,
+    comment: Some(
+        "Comment, likely a filename in practice!",
+    ),
+}

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down.snap
@@ -1,0 +1,6 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: m_valid0_down()
+snapshot_kind: text
+---
+M(up: "CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);", down: "DROP TABLE m1; DROP TABLE m2;")

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down_alt.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down_alt.snap
@@ -1,0 +1,9 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: "format!(\"{:#}\", m_valid0_down())"
+snapshot_kind: text
+---
+M(
+    up: "CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);", 
+    down: "DROP TABLE m1; DROP TABLE m2;"
+)

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down_fk.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down_fk.snap
@@ -1,0 +1,14 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: m_valid_fk_down()
+snapshot_kind: text
+---
+M(up: "
+        CREATE TABLE fk1(a PRIMARY KEY);
+        CREATE TABLE fk2(
+            a,
+            FOREIGN KEY(a) REFERENCES fk1(a)
+        );
+        INSERT INTO fk1 (a) VALUES ('foo');
+        INSERT INTO fk2 (a) VALUES ('foo');
+    ", down: "DELETE FROM fk2; DELETE FROM fk1; DROP TABLE fk2; DROP TABLE fk1;", foreign key check)

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down_fk_alt.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_down_fk_alt.snap
@@ -1,0 +1,18 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: "format!(\"{:#}\", m_valid_fk_down())"
+snapshot_kind: text
+---
+M(
+    up: "
+        CREATE TABLE fk1(a PRIMARY KEY);
+        CREATE TABLE fk2(
+            a,
+            FOREIGN KEY(a) REFERENCES fk1(a)
+        );
+        INSERT INTO fk1 (a) VALUES ('foo');
+        INSERT INTO fk2 (a) VALUES ('foo');
+    ", 
+    down: "DELETE FROM fk2; DELETE FROM fk1; DROP TABLE fk2; DROP TABLE fk1;", 
+    foreign key check
+)

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_only.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_only.snap
@@ -1,0 +1,6 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: m_valid0_up()
+snapshot_kind: text
+---
+M(up: "CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);")

--- a/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_only_alt.snap
+++ b/rusqlite_migration/src/tests/snapshots/rusqlite_migration__tests__core__up_only_alt.snap
@@ -1,0 +1,8 @@
+---
+source: rusqlite_migration/src/tests/core.rs
+expression: "format!(\"{:#}\", m_valid0_up())"
+snapshot_kind: text
+---
+M(
+    up: "CREATE TABLE m1(a, b); CREATE TABLE m2(a, b, c);"
+)


### PR DESCRIPTION

This is helpful when M is embedded in errors and just generally for
users. This representation is for humans and we do not implement
FromStr, we could change this in the future without causing a breaking
change.

See also [this opinion in an old Rust discussion thread][1]:

> my final answer to "is changing Display's output breaking" is "no if
> it's an Error, yes if it's FromStr, and you're doing it wrong
> otherwise."

[1]: https://users.rust-lang.org/t/are-changes-to-fmt-display-considered-breaking/59775/7

