### PR TITLE
fix: improve Display for errors

### DIFF
--- a/rusqlite_migration/src/errors.rs
+++ b/rusqlite_migration/src/errors.rs
@@ -86,9 +86,19 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::SpecifiedSchemaVersion(e) => write!(f, "rusqlite_migrate error: {e}"),
-            // TODO Format the error with fmt instead of debug
-            _ => write!(f, "rusqlite_migrate error: {self:?}"),
+            Error::RusqliteError { query, err: e } => write!(
+                f,
+                "rusqlite_migration error while executing query '{query}': {e}"
+            ),
+            Error::SpecifiedSchemaVersion(e) => {
+                write!(f, "error with the specified schema version: {e}")
+            }
+            Error::MigrationDefinition(e) => {
+                todo!()
+            }
+            Error::ForeignKeyCheck(vec) => todo!(),
+            Error::Unrecognized(ref e) => todo!(),
+            Error::Hook(_) | Error::FileLoad(_) | Error::InvalidUserVersion => todo!(),
         }
     }
 }

--- a/rusqlite_migration/src/errors/snapshots/rusqlite_migration__errors__tests__error_display__rusqlite_error.snap
+++ b/rusqlite_migration/src/errors/snapshots/rusqlite_migration__errors__tests__error_display__rusqlite_error.snap
@@ -3,4 +3,4 @@ source: rusqlite_migration/src/errors/tests.rs
 expression: e
 snapshot_kind: text
 ---
-rusqlite_migrate error: RusqliteError { query: "SELECT * FROM table42;", err: InvalidQuery }
+rusqlite_migrate error while executing query 'SELECT * FROM table42;': Query is not read-only

--- a/rusqlite_migration/src/errors/snapshots/rusqlite_migration__errors__tests__error_display__specified_schema_version.snap
+++ b/rusqlite_migration/src/errors/snapshots/rusqlite_migration__errors__tests__error_display__specified_schema_version.snap
@@ -3,4 +3,4 @@ source: rusqlite_migration/src/errors/tests.rs
 expression: e
 snapshot_kind: text
 ---
-rusqlite_migrate error: Attempt to migrate to version 0 (no version set), which is higher than the highest version currently supported, 0 (no version set).
+error with the specified schema version: Attempt to migrate to version 0 (no version set), which is higher than the highest version currently supported, 0 (no version set).

--- a/rusqlite_migration/src/errors/snapshots/rusqlite_migration__errors__tests__error_display__too_high_schema_version.snap
+++ b/rusqlite_migration/src/errors/snapshots/rusqlite_migration__errors__tests__error_display__too_high_schema_version.snap
@@ -3,4 +3,4 @@ source: rusqlite_migration/src/errors/tests.rs
 expression: e
 snapshot_kind: text
 ---
-rusqlite_migrate error: Attempt to use a schema version higher than supported.
+error with the specified schema version: Attempt to use a schema version higher than supported.


### PR DESCRIPTION
This is not a breaking change because Display is meant for human
consumption.

See also [this opinion in an old Rust discussion thread][1]:

> my final answer to "is changing Display's output breaking" is "no if
> it's an Error, yes if it's FromStr, and you're doing it wrong
> otherwise."

[1]: https://users.rust-lang.org/t/are-changes-to-fmt-display-considered-breaking/59775/7
