### PR TITLE
chore: update rusqlite and tokio-rusqlite-new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ end_insert -->
 Release notes for the [rusqlite_migration library](https://cj.rs/rusqlite_migration).
 end_insert -->
 
+## Version 2.2.0 Beta 1
+
+### Features
+
+- Implement the `Display` trait for `M`. This makes it easier to print errors pertaining to a particular migration (this feature is planned for the future, in the context of more extensive migration checks)
+
+### Dependencies
+
+Rusqlite was updated from 0.35.0 to 0.36.0.
+Please see [the release notes for 0.36.0](https://github.com/rusqlite/rusqlite/releases/tag/v0.36.0).
+
+### Other
+
+- Update development dependencies
+- Improve tests to cover more cases, in particular around downward migrations
+- Add docs.rs link to Cargo metadata
+- Fix clippy warning in rust 1.87.0
+
 ## Version 2.1.0
 
 ### Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,9 +536,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947e6816f7825b2b45027c2c32e7085da9934defa535de4a6a46b10a4d5257fa"
+checksum = "91632f3b4fb6bd1d72aa3d78f41ffecfcf2b1a6648d8c241dbe7dbfaf4875e15"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -793,9 +793,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rusqlite"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22715a5d6deef63c637207afbe68d0c72c3f8d0022d7cf9714c442d6157606b"
+checksum = "3de23c3319433716cf134eed225fe9986bc24f63bed9be9f20c329029e672dc7"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "2.1.0"
+version = "2.2.0-beta.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration_tests"
-version = "2.1.0"
+version = "2.2.0-beta.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1006,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite-new"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a040ff4d5e6323faf4adc2923fd9c1cea8e4ba3abf7063b8892bd53b5bd3587e"
+checksum = "1d5e39e7c825b55770bb03865ed55ab2cce6984c3dc6255f2d914a798cd84766"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/cljoly/rusqlite_migration"
 documentation = "https://docs.rs/rusqlite_migration/"
 rust-version = "1.84"
-version = "2.1.0"
+version = "2.2.0-beta.1"
 
 [workspace]
 members = [

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -10,13 +10,13 @@ simple-logging = "2.0.2"
 env_logger = "0.11"
 anyhow = "1"
 mktemp = "0.5"
-tokio-rusqlite-new = "=0.9.0"
+tokio-rusqlite-new = "=0.10.0"
 tokio = { version = "1.45.1", features = ["full"] }
 
 [dependencies.rusqlite_migration]
 path = "../../rusqlite_migration"
 
 [dependencies.rusqlite]
-version = "0.35.0"
+version = "0.36.0"
 default-features = false
 features = []

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -17,6 +17,6 @@ path = "../../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.35.0"
+version = "0.36.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -13,5 +13,5 @@ anyhow = "1"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "0.35.0"
+version = "0.36.0"
 features = ["extra_check"] # A realistic use case

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -34,7 +34,7 @@ include_dir = { version = "0.7.4", optional = true }
 log = "0.4"
 
 [dependencies.rusqlite]
-version = "0.35.0"
+version = "0.36.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -22,7 +22,7 @@ path = "../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.35.0"
+version = "0.36.0"
 features = ["extra_check"]
 
 [dev-dependencies]


### PR DESCRIPTION
Rusqlite changelog: https://github.com/rusqlite/rusqlite/releases/tag/v0.36.0

tokio-rusqlite-new diffs (looks fine):
```
diff -r -u --color=auto -x Cargo.lock ~/.cargo/registry/src/index.crates.io-*/tokio-rusqlite-new-0.{9.0/,10.0/}
```
```diff
diff -r -u '--color=auto' -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/.cargo_vcs_info.json /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/.cargo_vcs_info.json
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/.cargo_vcs_info.json	1970-01-01 00:00:01.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/.cargo_vcs_info.json	1970-01-01 00:00:01.000000000 +0000
@@ -1,6 +1,6 @@
 {
   "git": {
-    "sha1": "bf9def984c91f8375be376e946f4ee007e368d84"
+    "sha1": "b9ca28fc65d9547f3e11fa09e3033a49ca2009cf"
   },
   "path_in_vcs": ""
 }
\ No newline at end of file
diff -r -u '--color=auto' -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/CHANGELOG.md /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/CHANGELOG.md
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/CHANGELOG.md	2006-07-24 01:21:28.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/CHANGELOG.md	2006-07-24 01:21:28.000000000 +0000
@@ -8,6 +8,10 @@

 Nothing.

+# 0.10.0 (27 May 2025)
+
+- **updated:** To latest [rusqlite] version (`0.36`).
+
 # 0.9.0 (21 Apr 2025)

 - **updated:** To latest [rusqlite] version (`0.35`).
diff -r -u '--color=auto' -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/Cargo.toml
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml	1970-01-01 00:00:01.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/Cargo.toml	1970-01-01 00:00:01.000000000 +0000
@@ -12,7 +12,7 @@
 [package]
 edition = "2021"
 name = "tokio-rusqlite-new"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "xuxiaocheng <2762267080@qq.com>",
     "Programatik <programatik29@gmail.com>",
@@ -62,18 +62,18 @@
 version = "~0.5"

 [dependencies.rusqlite]
-version = "~0.35"
+version = "~0.36"

 [dependencies.tokio]
-version = "^1.44"
+version = "^1.45"
 features = ["sync"]

 [dev-dependencies.rusqlite]
-version = "~0.35"
+version = "~0.36"
 features = ["bundled"]

 [dev-dependencies.tokio]
-version = "^1.44"
+version = "^1.45"
 features = [
     "rt-multi-thread",
     "macros",
diff -r -u '--color=auto' -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml.orig /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/Cargo.toml.orig
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/Cargo.toml.orig2006-07-24 01:21:28.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/Cargo.toml.orig	2006-07-24 01:21:28.000000000 +0000
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rusqlite-new"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["xuxiaocheng <2762267080@qq.com>", "Programatik <programatik29@gmail.com>", "Adi Salimgereev <adisalimgereev@gmail.com>"]
 edition = "2021"
 description = "Asynchronous handle for rusqlite library."
@@ -15,12 +15,12 @@

 [dependencies]
 crossbeam-channel = "~0.5"
-rusqlite = "~0.35"
-tokio = { version = "^1.44", features = ["sync"] }
+rusqlite = "~0.36"
+tokio = { version = "^1.45", features = ["sync"] }

 [dev-dependencies]
-rusqlite = { version = "~0.35", features = ["bundled"] }
-tokio = { version = "^1.44", features = ["rt-multi-thread", "macros"] }
+rusqlite = { version = "~0.36", features = ["bundled"] }
+tokio = { version = "^1.45", features = ["rt-multi-thread", "macros"] }

 [[test]]
 name = "tests"
diff -r -u '--color=auto' -x Cargo.lock /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/src/lib.rs /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/src/lib.rs
--- /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.9.0/src/lib.rs	2006-07-24 01:21:28.000000000 +0000
+++ /home/cj/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-rusqlite-new-0.10.0/src/lib.rs	2006-07-24 01:21:28.000000000 +0000
@@ -166,7 +166,7 @@
 }

 use std::path::Path;
-use rusqlite::OpenFlags;
+use rusqlite::{Name, OpenFlags};

 async fn start<F>(open: F) -> Result<Connection>
 where
@@ -239,10 +239,10 @@
     ///
     /// Will return `Err` if either `path` or `vfs` cannot be converted to a
     /// C-compatible string or if the underlying SQLite open call fails.
-    pub async fn open_with_flags_and_vfs<P: AsRef<Path>>(path: P, flags: OpenFlags, vfs: &str) -> Result<Self> {
+    pub async fn open_with_flags_and_vfs<P: AsRef<Path>>(path: P, flags: OpenFlags, vfs: impl Name) -> Result<Self> {
         let path = path.as_ref().to_owned();
-        let vfs = vfs.to_owned();
-        start(move || rusqlite::Connection::open_with_flags_and_vfs(path, flags, &vfs)).await
+        let vfs = vfs.as_cstr()?.to_owned();
+        start(move || rusqlite::Connection::open_with_flags_and_vfs(path, flags, vfs.as_c_str())).await
     }

     /// Open a new connection to an in-memory SQLite database.
@@ -267,8 +267,8 @@
     ///
     /// Will return `Err` if `vfs` cannot be converted to a C-compatible
     /// string or if the underlying SQLite open call fails.
-    pub async fn open_in_memory_with_flags_and_vfs(flags: OpenFlags, vfs: &str) -> Result<Self> {
-        let vfs = vfs.to_owned();
-        start(move || rusqlite::Connection::open_in_memory_with_flags_and_vfs(flags, &vfs)).await
+    pub async fn open_in_memory_with_flags_and_vfs(flags: OpenFlags, vfs: impl Name) -> Result<Self> {
+        let vfs = vfs.as_cstr()?.to_owned();
+        start(move || rusqlite::Connection::open_in_memory_with_flags_and_vfs(flags, vfs.as_c_str())).await
     }
 }
```
