### PR TITLE
chore: fix clippy direct format strings

### DIFF
--- a/rusqlite_migration/build.rs
+++ b/rusqlite_migration/build.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .skip(1) // Discard the pattern line
         .filter(|line| *line != "</div>") // Known unclosed div because we don’t start from the top
         .try_fold(0, |lines_written, line| -> Result<usize, io::Error> {
-            writeln!(out, "{}", line)?;
+            writeln!(out, "{line}")?;
             Ok(lines_written + 1)
         })
         .map(|lines_written| {

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -486,7 +486,7 @@ impl<'m> Migrations<'m> {
     fn db_version_to_schema(&self, db_version: usize) -> SchemaVersion {
         match db_version {
             0 => SchemaVersion::NoneSet,
-            v if v > 0 && v <= self.ms.len() => SchemaVersion::Inside(
+            v if v <= self.ms.len() => SchemaVersion::Inside(
                 NonZeroUsize::new(v).expect("schema version should not be equal to 0"),
             ),
             v => SchemaVersion::Outside(

--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -666,7 +666,7 @@ impl<'m> Migrations<'m> {
             .take(current_version - target_version)
             .find(|(_, m)| m.down.is_none())
         {
-            warn!("Cannot revert: {:?}", bad_m);
+            warn!("Cannot revert: {bad_m:?}");
             return Err(Error::MigrationDefinition(
                 MigrationDefinitionError::DownNotDefined { migration_index: i },
             ));
@@ -711,8 +711,7 @@ impl<'m> Migrations<'m> {
                     ));
                 }
                 debug!(
-                    "rollback to older version requested, target_db_version: {}, current_version: {}",
-                    target_db_version, current_version
+                    "rollback to older version requested, target_db_version: {target_db_version}, current_version: {current_version}",
                 );
                 self.goto_down(conn, current_version, target_db_version)
             }
@@ -729,7 +728,7 @@ impl<'m> Migrations<'m> {
         };
 
         if res.is_ok() {
-            info!("Database migrated to version {}", target_db_version);
+            info!("Database migrated to version {target_db_version}");
         }
         res
     }
@@ -940,7 +939,7 @@ fn user_version(conn: &Connection) -> Result<usize> {
 
 // Set user version field from the SQLite db
 fn set_user_version(conn: &Connection, v: usize) -> Result<()> {
-    trace!("set user version to: {}", v);
+    trace!("set user version to: {v}");
     let v = if v > MIGRATIONS_MAX {
         Err(Error::SpecifiedSchemaVersion(SchemaVersionError::TooHigh))
     } else {


### PR DESCRIPTION
This is a new warning, presumably with Rust 1.88.
