### PR TITLE
chore: update rusqlite and bump version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ end_insert -->
 Release notes for the [rusqlite_migration library](https://cj.rs/rusqlite_migration).
 end_insert -->
 
+## Version 2.3.0
+
+### Dependencies
+
+Rusqlite was updated from 0.36.0 to 0.37.0.
+Please see [the release notes for 0.37.0](https://github.com/rusqlite/rusqlite/releases/tag/v0.37.0).
+
+### Other
+
+- Misc. clippy fixes
+- Minor improvements to the example in the Readme
+
 ## Version 2.2.0
 
 > [!NOTE]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,9 +547,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91632f3b4fb6bd1d72aa3d78f41ffecfcf2b1a6648d8c241dbe7dbfaf4875e15"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -804,9 +804,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rusqlite"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de23c3319433716cf134eed225fe9986bc24f63bed9be9f20c329029e672dc7"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration_tests"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite-new"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5e39e7c825b55770bb03865ed55ab2cce6984c3dc6255f2d914a798cd84766"
+checksum = "49eaf3f1d067e7d4c0981e27689f1349b11032956852e7ec3705e549a74c0821"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/cljoly/rusqlite_migration"
 documentation = "https://docs.rs/rusqlite_migration/"
 rust-version = "1.84"
-version = "2.2.0"
+version = "2.3.0"
 
 [workspace]
 members = [

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -17,6 +17,6 @@ tokio = { version = "1.46.1", features = ["full"] }
 path = "../../rusqlite_migration"
 
 [dependencies.rusqlite]
-version = "0.36.0"
+version = "0.37.0"
 default-features = false
 features = []

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -10,7 +10,7 @@ simple-logging = "2.0.2"
 env_logger = "0.11"
 anyhow = "1"
 mktemp = "0.5"
-tokio-rusqlite-new = "=0.10.0"
+tokio-rusqlite-new = "=0.11.0"
 tokio = { version = "1.46.1", features = ["full"] }
 
 [dependencies.rusqlite_migration]

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -17,6 +17,6 @@ path = "../../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.36.0"
+version = "0.37.0"
 default-features = false
 features = []

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -13,5 +13,5 @@ anyhow = "1"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "0.36.0"
+version = "0.37.0"
 features = ["extra_check"] # A realistic use case

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -34,7 +34,7 @@ include_dir = { version = "0.7.4", optional = true }
 log = "0.4"
 
 [dependencies.rusqlite]
-version = "0.36.0"
+version = "0.37.0"
 default-features = false
 features = []
 

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -22,7 +22,7 @@ path = "../rusqlite_migration"
 features = ["from-directory"]
 
 [dependencies.rusqlite]
-version = "0.36.0"
+version = "0.37.0"
 features = ["extra_check"]
 
 [dev-dependencies]


### PR DESCRIPTION
- [X] Update rusqlite to 0.37
- [X] Update changelog
- [X] Bump version in Cargo.toml
- [X] Update tokio-rusqlite-new ([diff](https://gist.github.com/cljoly/fb18f21208dbf3ab749a3a45cfca67db))
