### PR TITLE
test: add a test for the no leading 0 case

### DIFF
--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/1-t1/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/1-t1/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t1 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/10-t10/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/10-t10/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t10 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/11-t11/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/11-t11/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t11 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/12-t12/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/12-t12/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t12 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/2-t2/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/2-t2/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t2 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/3-t3/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/3-t3/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t3 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/4-t4/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/4-t4/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t4 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/5-t5/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/5-t5/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t5 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/6-t6/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/6-t6/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t6 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/7-t7/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/7-t7/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t7 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/8-t8/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/8-t8/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t8 (a);

--- a/rusqlite_migration_tests/tests/migrations/no_leading_zero/9-t9/up.sql
+++ b/rusqlite_migration_tests/tests/migrations/no_leading_zero/9-t9/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t9 (a);


### PR DESCRIPTION
When defining migrations from a directory, the example pads the
migration id with leading zeros. While this is a good practice, if a
user doesn’t do that, we still accept the migrations and process them in
numerical order (which is not the lexicographic order, i.e. 1, 10, 2,
20, 3, 4...).

Add a test to capture both that this is valid and handled in numerical
order. This is both for completeness of the test suite and in case we
change the implementation (e.g. #288).
