### PR TITLE
chore: bump msrv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: Continuous integration
 permissions: {}
 
 env:
-  MSRV: 1.84.0
+  MSRV: 1.94.0
   CARGO_TERM_COLOR: always
   # Useful for cargo insta
   CI: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
 license = "Apache-2.0"
 repository = "https://github.com/cljoly/rusqlite_migration"
 documentation = "https://docs.rs/rusqlite_migration/"
-rust-version = "1.84"
+rust-version = "1.94"
 version = "2.5.0"
 
 [workspace]


### PR DESCRIPTION
This is to keep us aligned with the MSRV from rusqlite. For the latest release it looks like our MSRV is still valid, CI was not failing. So no need to release a new version because of that.