### PR TITLE
chore: factor out rusqlite version in workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ resolver = "2"
 [workspace.lints.rust]
 unsafe_code = "forbid"
 missing_docs = "warn"
+
+[workspace.dependencies.rusqlite]
+version = "0.39.0"
+default-features = false
+features = []

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -8,16 +8,12 @@ publish = false
 log = "0.4"
 anyhow = "1"
 mktemp = "0.5"
+rusqlite = { workspace = true }
 tokio-rusqlite-new = "=0.13.0"
 tokio = { version = "1.49.0", features = ["full"] }
 
 [dependencies.rusqlite_migration]
 path = "../../rusqlite_migration"
-
-[dependencies.rusqlite]
-version = "0.39.0"
-default-features = false
-features = []
 
 [dependencies.env_logger]
 version = "0.11"

--- a/examples/from-directory/Cargo.toml
+++ b/examples/from-directory/Cargo.toml
@@ -9,15 +9,11 @@ log = "0.4"
 anyhow = "1"
 mktemp = "0.5"
 include_dir = "0.7.4"
+rusqlite = { workspace = true }
 
 [dependencies.rusqlite_migration]
 path = "../../rusqlite_migration"
 features = ["from-directory"]
-
-[dependencies.rusqlite]
-version = "0.39.0"
-default-features = false
-features = []
 
 [dependencies.env_logger]
 version = "0.11"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 mktemp = "0.5"
 
 [dependencies.rusqlite]
-version = "0.39.0"
+workspace = true
 features = ["extra_check"] # A realistic use case
 
 [dependencies.env_logger]

--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -32,11 +32,7 @@ from-directory = ["dep:include_dir"]
 [dependencies]
 include_dir = { version = "0.7.4", optional = true }
 log = "0.4"
-
-[dependencies.rusqlite]
-version = "0.39.0"
-default-features = false
-features = []
+rusqlite = { workspace = true , default-features = false}
 
 [dev-dependencies]
 anyhow = "1"

--- a/rusqlite_migration_benches/Cargo.toml
+++ b/rusqlite_migration_benches/Cargo.toml
@@ -14,11 +14,7 @@ version.workspace = true
 
 [dependencies]
 include_dir = { version = "0.7.4" }
-
-[dependencies.rusqlite]
-version = "0.39.0"
-default-features = false
-features = []
+rusqlite = { workspace = true }
 
 [dependencies.rusqlite_migration]
 path = "../rusqlite_migration"

--- a/rusqlite_migration_tests/Cargo.toml
+++ b/rusqlite_migration_tests/Cargo.toml
@@ -16,14 +16,11 @@ version.workspace = true
 
 [dependencies]
 log = "0.4"
+rusqlite = { workspace = true, features = ["extra_check"] }
 
 [dependencies.rusqlite_migration]
 path = "../rusqlite_migration"
 features = ["from-directory"]
-
-[dependencies.rusqlite]
-version = "0.39.0"
-features = ["extra_check"]
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
These versions have to be in sync, because rusqlite_migration depends on
it and everything else depends on rusqlite_migration. So if rusqlite
versions don’t match, packages can't compile.

I'm pretty sure this still applies the “no default features” instruction
correctly, even if that has proven hard to test. For instance,
```diff
diff --git a/rusqlite_migration/src/lib.rs b/rusqlite_migration/src/lib.rs
index 8e35501..be88f3d 100644
--- a/rusqlite_migration/src/lib.rs
+++ b/rusqlite_migration/src/lib.rs
@@ -926,6 +926,8 @@ pub fn to_version(&self, conn: &mut Connection, version: usize) -> Result<()> {
     /// Returns [`Error::RusqliteError`] if the underlying sqlite database open call fails.
     pub fn validate(&self) -> Result<()> {
         let mut conn = Connection::open_in_memory()?;
+        conn.prepare_cached("SELECT 1").unwrap();
+        conn.set_prepared_statement_cache_capacity(10);
         self.to_latest(&mut conn)
     }
 }
```

compiles, with or without this change, even if the
[docs](https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#method.prepare_cached)
says it should require the `cache` feature.

But the output of `cargo tree -p rusqlite_migration -e features,normal --no-dedupe` stays the same before and after this change:

```
rusqlite_migration v2.5.0 (/home/cjoly/ghq/github.com/cljoly/rusqlite_migration/rusqlite_migration)
├── rusqlite v0.39.0
│   ├── bitflags feature "default"
│   │   └── bitflags v2.9.0
│   ├── fallible-iterator feature "default"
│   │   ├── fallible-iterator v0.3.0
│   │   └── fallible-iterator feature "alloc"
│   │       └── fallible-iterator v0.3.0
│   ├── fallible-streaming-iterator feature "default"
│   │   └── fallible-streaming-iterator v0.1.9
│   ├── libsqlite3-sys feature "default"
│   │   ├── libsqlite3-sys v0.37.0
│   │   └── libsqlite3-sys feature "min_sqlite_version_3_34_1"
│   │       ├── libsqlite3-sys v0.37.0
│   │       ├── libsqlite3-sys feature "pkg-config"
│   │       │   └── libsqlite3-sys v0.37.0
│   │       └── libsqlite3-sys feature "vcpkg"
│   │           └── libsqlite3-sys v0.37.0
│   └── smallvec feature "default"
│       └── smallvec v1.15.0
└── log feature "default"
    └── log v0.4.29
```

And if one removes the “no default” for rusqlite, the output does show the default feature being selected. I.e. with

```diff
diff --git a/rusqlite_migration/Cargo.toml b/rusqlite_migration/Cargo.toml
index 5f49e3c..d96e884 100644
--- a/rusqlite_migration/Cargo.toml
+++ b/rusqlite_migration/Cargo.toml
@@ -35,8 +35,6 @@ log = "0.4"
 
 [dependencies.rusqlite]
 version = "0.39.0"
-default-features = false
-features = []
 
 [dev-dependencies]
 anyhow = "1"
```

the output of `cargo tree -p rusqlite_migration -e features,normal --no-dedupe` shows the various features:

<details><summary>Details</summary>
<p>

```
rusqlite_migration v2.5.0 (/home/cjoly/ghq/github.com/cljoly/rusqlite_migration/rusqlite_migration)
├── log feature "default"
│   └── log v0.4.29
└── rusqlite feature "default"
    ├── rusqlite v0.39.0
    │   ├── bitflags feature "default"
    │   │   └── bitflags v2.9.0
    │   ├── fallible-iterator feature "default"
    │   │   ├── fallible-iterator v0.3.0
    │   │   └── fallible-iterator feature "alloc"
    │   │       └── fallible-iterator v0.3.0
    │   ├── fallible-streaming-iterator feature "default"
    │   │   └── fallible-streaming-iterator v0.1.9
    │   ├── hashlink feature "default"
    │   │   └── hashlink v0.11.0
    │   │       └── hashbrown feature "default-hasher"
    │   │           └── hashbrown v0.16.1
    │   │               └── foldhash v0.2.0
    │   ├── libsqlite3-sys feature "default"
    │   │   ├── libsqlite3-sys v0.37.0
    │   │   └── libsqlite3-sys feature "min_sqlite_version_3_34_1"
    │   │       ├── libsqlite3-sys v0.37.0
    │   │       ├── libsqlite3-sys feature "pkg-config"
    │   │       │   └── libsqlite3-sys v0.37.0
    │   │       └── libsqlite3-sys feature "vcpkg"
    │   │           └── libsqlite3-sys v0.37.0
    │   └── smallvec feature "default"
    │       └── smallvec v1.15.0
    └── rusqlite feature "cache"
        ├── rusqlite v0.39.0
        │   ├── bitflags feature "default"
        │   │   └── bitflags v2.9.0
        │   ├── fallible-iterator feature "default"
        │   │   ├── fallible-iterator v0.3.0
        │   │   └── fallible-iterator feature "alloc"
        │   │       └── fallible-iterator v0.3.0
        │   ├── fallible-streaming-iterator feature "default"
        │   │   └── fallible-streaming-iterator v0.1.9
        │   ├── hashlink feature "default"
        │   │   └── hashlink v0.11.0
        │   │       └── hashbrown feature "default-hasher"
        │   │           └── hashbrown v0.16.1
        │   │               └── foldhash v0.2.0
        │   ├── libsqlite3-sys feature "default"
        │   │   ├── libsqlite3-sys v0.37.0
        │   │   └── libsqlite3-sys feature "min_sqlite_version_3_34_1"
        │   │       ├── libsqlite3-sys v0.37.0
        │   │       ├── libsqlite3-sys feature "pkg-config"
        │   │       │   └── libsqlite3-sys v0.37.0
        │   │       └── libsqlite3-sys feature "vcpkg"
        │   │           └── libsqlite3-sys v0.37.0
        │   └── smallvec feature "default"
        │       └── smallvec v1.15.0
        └── rusqlite feature "hashlink"
            └── rusqlite v0.39.0
                ├── bitflags feature "default"
                │   └── bitflags v2.9.0
                ├── fallible-iterator feature "default"
                │   ├── fallible-iterator v0.3.0
                │   └── fallible-iterator feature "alloc"
                │       └── fallible-iterator v0.3.0
                ├── fallible-streaming-iterator feature "default"
                │   └── fallible-streaming-iterator v0.1.9
                ├── hashlink feature "default"
                │   └── hashlink v0.11.0
                │       └── hashbrown feature "default-hasher"
                │           └── hashbrown v0.16.1
                │               └── foldhash v0.2.0
                ├── libsqlite3-sys feature "default"
                │   ├── libsqlite3-sys v0.37.0
                │   └── libsqlite3-sys feature "min_sqlite_version_3_34_1"
                │       ├── libsqlite3-sys v0.37.0
                │       ├── libsqlite3-sys feature "pkg-config"
                │       │   └── libsqlite3-sys v0.37.0
                │       └── libsqlite3-sys feature "vcpkg"
                │           └── libsqlite3-sys v0.37.0
                └── smallvec feature "default"
                    └── smallvec v1.15.0
```

</p>
</details>

See
https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
and
https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
