### PR TITLE
chore: bump MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: Continuous integration
 permissions: {}
 
 env:
-  MSRV: 1.94.0
+  MSRV: 1.95.0
   CARGO_TERM_COLOR: always
   # Useful for cargo insta
   CI: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["rusqlite", "sqlite", "user_version", "database", "migration"]
 license = "Apache-2.0"
 repository = "https://github.com/cljoly/rusqlite_migration"
 documentation = "https://docs.rs/rusqlite_migration/"
-rust-version = "1.94"
+rust-version = "1.95"
 version = "2.5.0"
 
 [workspace]


### PR DESCRIPTION
At the time rusqlite was released [1], 26 May 2026, the latest rustc
version was 1.95 (1.96 came out 28 May 2026). So this is the new Minimum
Supported Rust Version (MSRV) per their policy.

Bump configurations accordingly

[1] https://github.com/rusqlite/rusqlite/releases/tag/v0.40.0
